### PR TITLE
fix: Individual classes doesn't break build

### DIFF
--- a/app/classes/[slug]/page.tsx
+++ b/app/classes/[slug]/page.tsx
@@ -106,16 +106,22 @@ export default async function Page({ params }: ClassPageProps) {
   )
 }
 
-export async function generateStaticParams(): Promise<{ params: { slug: string } }[]> {
-  try {
-    const { masterClasses } = await upcomingSessions({})
-    return masterClasses.map((masterClass) => ({
-      params: {
-        slug: masterClass.displayName.toLowerCase().replace(/\s+/g, '-'),
-      }
-    }))
-  } catch (error) {
-    console.error("Failed to generate static params:", error)
-    return [] 
-  }
-}
+export const dynamic = "force-dynamic"
+
+// TODO: FIGURE THIS OUT. THE STATIC SITE GENERATION WORKS BUT THE CACHE KEEPS KRONNING AROUND
+// export async function generateStaticParams() {
+//   try {
+//     const { masterClasses } = await upcomingSessions({})
+//     return await Promise.all(masterClasses.map(async (masterClass) => {
+//       const slug = masterClass.displayName.toLowerCase().replace(/\s+/g, '-');
+//       const fullMasterClass = await getMasterClass({ name: "masterClasses/" + slug });
+//       return { 
+//         slug,
+//         masterClass: fullMasterClass 
+//       };
+//     }));
+//   } catch (error) {
+//     console.error("Failed to generate static params:", error)
+//     return [] 
+//   }
+// }

--- a/app/classes/actions.ts
+++ b/app/classes/actions.ts
@@ -18,8 +18,7 @@ export async function upcomingSessions(
   request: UpcomingSessionsRequest,
 ): Promise<UpcomingSessionResponse> {
   try {
-    // TODO: Why was cookies gotten here? Why did we want to prevent cache?
-    // cookies().getAll() // read cookies to prevent cache
+    cookies().getAll() // read cookies to prevent cache
     return await UpcomingSessions(request, {})
   } catch (e: unknown) {
     if (e instanceof TwirpError) {
@@ -36,7 +35,7 @@ export async function getMasterClass(
 ): Promise<MasterClass> {
   try {
     return await GetMasterClass(request, {
-      headers: await authHeader(),
+      headers: await authHeader(), // this calls cookies and makes components using it not be able to SSG
     })
   } catch (e: unknown) {
     if (e instanceof TwirpError) {

--- a/app/confirmed-booking/page.tsx
+++ b/app/confirmed-booking/page.tsx
@@ -89,7 +89,6 @@ const ConfirmedBooking: React.FC = () => {
           <div className="pt-10">
             <div className="mb-20 items-start justify-start py-4 text-center sm:text-start md:flex md:space-x-8 lg:justify-start lg:px-0">
               {/* TODO: BYOB: Build your own button */}
-              <Link href="/">
                 <AddToCalendarButton
                   label="Add to calendar"
                   name="Workshop Tour"
@@ -102,7 +101,6 @@ const ConfirmedBooking: React.FC = () => {
                   // TODO Description to be discussed
                   description="Workshop Tour at Made In Workshop"
                 />
-              </Link>
               <div className="flex items-center justify-center">
                 <Link href="/">
                   <SmallButtonOrange color="primary">

--- a/app/machines/page.tsx
+++ b/app/machines/page.tsx
@@ -1,11 +1,9 @@
 import React, { Suspense } from "react"
 import IndustrialMachineTools from "@/components/base/IndustrialMachineTools"
-import Link from "next/link"
 import GetInTouch from "@/components/base/getInTouch"
 import { listMachines } from "./actions"
 import { Spinner } from "@/components/ui/spinner"
 import HeaderTitle from "@/components/header-title"
-import { Breadcrumb } from "@/components/ui/breadcrumb"
 import { Breadcrumbs } from "@/components/breadcrumbs"
 
 export default async function Page() {

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -11,11 +11,16 @@ import {
   CarouselItem,
 } from "@/components/ui/carousel"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { notFound } from "next/navigation"
 
 
 export default async function Page() {
 
   const posts = await getPosts()
+
+  if (!posts) {
+    notFound()
+  }
 
   return (
     <div className={"bg-background py-10"}>


### PR DESCRIPTION
The pages are dynamically rendered now
The add to calendar will no longer redirect