### PR TITLE
fix: :zap: Updated 30 Day Membership Grammar

### DIFF
--- a/components/base/pricing-table.tsx
+++ b/components/base/pricing-table.tsx
@@ -137,9 +137,9 @@ a professional workspace on a part-time
 basis."
         />
 
-        {/* Pricing tab 4 : 30 Days Membership */}
+        {/* Pricing tab 4 : 30 Day Membership */}
         <PricingTab
-          planName="30 Days Membership"
+          planName="30 Day Membership"
           price="8799"
           planDescription="The monthly membership is our
 premium offering, providing everything


### PR DESCRIPTION
Updated 30 Day Membership Grammar

This pull request makes a minor correction in the `components/base/pricing-table.tsx` file, updating the label from "30 Days Membership" to "30 Day Membership" for consistency and grammatical accuracy.