### PR TITLE
build: upgrade twirpscript 0.0.72 / protoscript 0.0.23 to match pepper-mint

### DIFF
--- a/lib/fusion/auth/role.pb.ts
+++ b/lib/fusion/auth/role.pb.ts
@@ -10,12 +10,7 @@ import * as protoscript from "protoscript";
 //========================================//
 
 export type Role =
-  | "NONE"
-  | "GUEST"
-  | "MEMBER"
-  | "ADMIN"
-  | "SUPER_ADMIN"
-  | "SYSTEM";
+  "NONE" | "GUEST" | "MEMBER" | "ADMIN" | "SUPER_ADMIN" | "SYSTEM";
 
 export interface required {}
 

--- a/lib/fusion/commerce/order.pb.ts
+++ b/lib/fusion/commerce/order.pb.ts
@@ -63,10 +63,7 @@ export interface Order {
 
 export declare namespace Order {
   export type Status =
-    | "STATUS_UNSPECIFIED"
-    | "PENDING"
-    | "COMPLETED"
-    | "CANCELLED";
+    "STATUS_UNSPECIFIED" | "PENDING" | "COMPLETED" | "CANCELLED";
 
   /**
    * coupons applied to this order

--- a/lib/fusion/masterClass/masterClass.pb.ts
+++ b/lib/fusion/masterClass/masterClass.pb.ts
@@ -73,10 +73,7 @@ export interface MasterClass {
 
 export declare namespace MasterClass {
   export type Difficulty =
-    | "UNSPECIFIED"
-    | "BEGINNER"
-    | "INTERMEDIATE"
-    | "ADVANCED";
+    "UNSPECIFIED" | "BEGINNER" | "INTERMEDIATE" | "ADVANCED";
 }
 
 //========================================//

--- a/lib/fusion/workshop/tourBooking.repository.sky.pb.ts
+++ b/lib/fusion/workshop/tourBooking.repository.sky.pb.ts
@@ -211,20 +211,17 @@ export interface TourBookingRepository<Context = unknown> {
     createTourBookingRequest: CreateTourBookingRequest,
     context: Context,
   ) =>
-    | Promise<workshopTourBooking.TourBooking>
-    | workshopTourBooking.TourBooking;
+    Promise<workshopTourBooking.TourBooking> | workshopTourBooking.TourBooking;
   GetTourBooking: (
     getTourBookingRequest: GetTourBookingRequest,
     context: Context,
   ) =>
-    | Promise<workshopTourBooking.TourBooking>
-    | workshopTourBooking.TourBooking;
+    Promise<workshopTourBooking.TourBooking> | workshopTourBooking.TourBooking;
   UpdateTourBooking: (
     updateTourBookingRequest: UpdateTourBookingRequest,
     context: Context,
   ) =>
-    | Promise<workshopTourBooking.TourBooking>
-    | workshopTourBooking.TourBooking;
+    Promise<workshopTourBooking.TourBooking> | workshopTourBooking.TourBooking;
   DeleteTourBooking: (
     deleteTourBookingRequest: DeleteTourBookingRequest,
     context: Context,

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "next": "^14.1.0",
         "next-mdx-remote": "^4.4.1",
         "next-navigation": "^1.0.6",
+        "protoscript": "^0.0.23",
         "react": "^18",
         "react-css-spinners": "^4.0.2",
         "react-dom": "^18",
@@ -70,7 +71,7 @@
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7",
         "tailwindcss-debug-screens": "^2.2.1",
-        "twirpscript": "^0.0.69",
+        "twirpscript": "^0.0.72",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -10651,9 +10652,10 @@
       }
     },
     "node_modules/protoscript": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/protoscript/-/protoscript-0.0.20.tgz",
-      "integrity": "sha512-NuXZgSko5o5o/ngA4/lccAHE7dY2C2ySaRTl+k45ehsjXitoQRXZ4fDAr5yIUadTAV9pZi6jQ0Ao5VQ9SBt0Ew==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/protoscript/-/protoscript-0.0.23.tgz",
+      "integrity": "sha512-5PB7ERq8ApyY+5T2bLLQaZHWis9ysm1PzIVX9GO5fjtGO/6EnVxFglzLouaxQPR+l2wF7XmEn+VNjlXCD1TQow==",
+      "license": "MIT",
       "dependencies": {
         "google-protobuf": "^3.21.2",
         "prettier": "^3.0.3"
@@ -12320,11 +12322,12 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/twirpscript": {
-      "version": "0.0.69",
-      "resolved": "https://registry.npmjs.org/twirpscript/-/twirpscript-0.0.69.tgz",
-      "integrity": "sha512-BZL6hky+OpGU5fozsw0CupJMbz69nvaRQL6OerCxDnZnk7AAjnB0s8qSQk6hVHb7OXrHOZBf/L2G4ttOUTqMyQ==",
+      "version": "0.0.72",
+      "resolved": "https://registry.npmjs.org/twirpscript/-/twirpscript-0.0.72.tgz",
+      "integrity": "sha512-KpVuqkzO95wMdvmK+GzXn+g/VFFGWJmgn3s8eXfIT+DmJ1nudAU3m9F/ets2byKyN1TXd3atWRCQlQpIj4jl+w==",
+      "license": "MIT",
       "dependencies": {
-        "protoscript": "0.0.20"
+        "protoscript": "0.0.23"
       },
       "bin": {
         "twirpscript": "dist/cli/index.js"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "next": "^14.1.0",
     "next-mdx-remote": "^4.4.1",
     "next-navigation": "^1.0.6",
+    "protoscript": "^0.0.23",
     "react": "^18",
     "react-css-spinners": "^4.0.2",
     "react-dom": "^18",
@@ -71,7 +72,7 @@
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",
     "tailwindcss-debug-screens": "^2.2.1",
-    "twirpscript": "^0.0.69",
+    "twirpscript": "^0.0.72",
     "zod": "^3.23.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #113.

## Summary
Bumps cool-mint's Twirp client toolchain to match pepper-mint (PR #141), which pinned TS-client generation to **twirpscript@0.0.72** with paired runtime **protoscript@0.0.23**. cool-mint was a version behind (twirpscript ^0.0.69 / protoscript 0.0.20, protoscript only transitive).

## Changes
- **`twirpscript`** `^0.0.69` → `^0.0.72`
- **`protoscript`** added as a direct dependency `^0.0.23` — the generated `.pb.ts` clients import it directly for message types; it was previously only pulled in transitively via twirpscript.
- **Regenerated `lib/fusion/`** using pepper-mint's own pinned pipeline: `task pre-compile` (sky `.sky.proto`) → `task gen-ts` (`twirpscript@0.0.72`), then copied the output into `lib/fusion/` exactly as `scripts/copy-ts.sh` does. Only **4 files** changed — the 0.0.72 prettier union-collapse reformat — the same set and kind of change PR #141 produced in the dashboard (`role.pb.ts`, `order.pb.ts`, `masterClass.pb.ts`, `tourBooking.repository.sky.pb.ts`).
- Refreshed `package-lock.json` (protoscript resolves to 0.0.23, deduped).

## Notes
- The regenerated 63-file set is a strict subset of cool-mint's committed `lib/fusion/`; 8 pre-existing stale generated files (e.g. `commerce/order-manager.pb.ts`) are not produced by the current pepper-mint proto and are **not imported by any app code**. Left untouched here to match `copy-ts.sh`'s additive behavior — cleaning them up is out of scope for this version bump.

## Verification
- `npm install` — lockfile refreshed, `twirpscript@0.0.72` + `protoscript@0.0.23` (deduped) installed.
- `tsc --noEmit` — **passes clean** (same verification method PR #141 used on the dashboard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)