### PR TITLE
feat: rebuild class gallery as carousel with lightbox

### DIFF
--- a/app/classes/[slug]/page.tsx
+++ b/app/classes/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import GetInTouch from "@/components/base/getInTouch"
 import { BookingCard } from "@/components/booking-card"
+import { ClassGallery } from "@/components/class-gallery"
 import { RelatedClasses } from "@/components/related-classes"
 import { Skeleton } from "@/components/ui/skeleton"
 import { moneyFormatter } from "@/lib/util/money-formatter"
@@ -153,28 +154,13 @@ export default async function Page({ params }: ClassPageProps) {
           </div>
 
           {/* Class Images */}
-          {masterClass.gallery.images[0] && (
-            <div className="grid grid-cols-1 gap-4 py-10 md:grid-cols-2">
-              <div className="relative h-[480px] overflow-hidden rounded-lg">
-                <Image
-                  src={masterClass.gallery.images[0].url}
-                  alt={"Gallery Image"}
-                  className="object-cover"
-                  fill
-                />
-              </div>
-              {masterClass.gallery.images[1] && (
-                <div className="relative h-[480px] overflow-hidden rounded-lg">
-                  <Image
-                    src={masterClass.gallery.images[1].url}
-                    alt={"Gallery Image"}
-                    className="object-cover"
-                    fill
-                  />
-                </div>
-              )}
-            </div>
-          )}
+          <ClassGallery
+            images={masterClass.gallery.images.map((i) => ({
+              url: i.url,
+              description: i.description,
+            }))}
+            title={masterClass.displayName}
+          />
 
           {masterClassSessions.length > 0 && (
             <>

--- a/components/class-gallery.smoke.test.tsx
+++ b/components/class-gallery.smoke.test.tsx
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+describe("rtl setup", () => {
+  it("renders JSX and matches jest-dom matchers", () => {
+    render(<p>hello gallery</p>)
+    expect(screen.getByText("hello gallery")).toBeInTheDocument()
+  })
+})

--- a/components/class-gallery.smoke.test.tsx
+++ b/components/class-gallery.smoke.test.tsx
@@ -1,9 +1,0 @@
-import { describe, it, expect } from "vitest"
-import { render, screen } from "@testing-library/react"
-
-describe("rtl setup", () => {
-  it("renders JSX and matches jest-dom matchers", () => {
-    render(<p>hello gallery</p>)
-    expect(screen.getByText("hello gallery")).toBeInTheDocument()
-  })
-})

--- a/components/class-gallery.test.tsx
+++ b/components/class-gallery.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { ClassGallery } from "@/components/class-gallery"
 
 const img = (n: number, desc = "") => ({
@@ -44,5 +45,18 @@ describe("ClassGallery", () => {
     expect(
       screen.getAllByRole("button", { name: /go to image/i }),
     ).toHaveLength(3)
+  })
+
+  it("opens a lightbox dialog when an image is clicked", async () => {
+    const user = userEvent.setup()
+    render(
+      <ClassGallery
+        images={[img(1, "A lathe"), img(2, "A chisel")]}
+        title="Woodworking 101"
+      />,
+    )
+    expect(screen.queryByRole("dialog")).toBeNull()
+    await user.click(screen.getAllByAltText("A lathe")[0])
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
   })
 })

--- a/components/class-gallery.test.tsx
+++ b/components/class-gallery.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ClassGallery } from "@/components/class-gallery"
+
+const img = (n: number, desc = "") => ({
+  url: `https://storage.googleapis.com/made-in-workshop/g${n}.jpg`,
+  description: desc,
+})
+
+describe("ClassGallery", () => {
+  it("renders nothing when there are no images", () => {
+    const { container } = render(
+      <ClassGallery images={[]} title="Woodworking 101" />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders a single image without carousel controls", () => {
+    render(
+      <ClassGallery images={[img(1, "A lathe")]} title="Woodworking 101" />,
+    )
+    expect(screen.getByAltText("A lathe")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /previous|next/i })).toBeNull()
+  })
+
+  it("renders all images and carousel controls for 2+ images", () => {
+    render(
+      <ClassGallery
+        images={[img(1, "A lathe"), img(2), img(3, "A chisel")]}
+        title="Woodworking 101"
+      />,
+    )
+    // all three images present
+    expect(screen.getByAltText("A lathe")).toBeInTheDocument()
+    expect(screen.getByAltText("A chisel")).toBeInTheDocument()
+    // empty description falls back to the class title
+    expect(screen.getAllByAltText("Woodworking 101").length).toBe(1)
+    // arrows present
+    expect(
+      screen.getByRole("button", { name: /previous/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument()
+    // one pagination dot per image
+    expect(
+      screen.getAllByRole("button", { name: /go to image/i }),
+    ).toHaveLength(3)
+  })
+})

--- a/components/class-gallery.tsx
+++ b/components/class-gallery.tsx
@@ -1,0 +1,99 @@
+"use client"
+
+import * as React from "react"
+import Image from "next/image"
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel"
+import { cn } from "@/lib/utils"
+
+export type GalleryImage = { url: string; description: string }
+
+const IMAGE_SIZES = "(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1200px"
+
+function altFor(image: GalleryImage, title: string): string {
+  return image.description.trim() || title
+}
+
+export function ClassGallery({
+  images,
+  title,
+}: {
+  images: GalleryImage[]
+  title: string
+}) {
+  const [api, setApi] = React.useState<CarouselApi>()
+  const [selected, setSelected] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!api) return
+    setSelected(api.selectedScrollSnap())
+    const onSelect = () => setSelected(api.selectedScrollSnap())
+    api.on("select", onSelect)
+    return () => {
+      api.off("select", onSelect)
+    }
+  }, [api])
+
+  if (images.length === 0) return null
+
+  if (images.length === 1) {
+    return (
+      <div className="py-10">
+        <div className="relative h-[480px] overflow-hidden rounded-lg">
+          <Image
+            src={images[0].url}
+            alt={altFor(images[0], title)}
+            className="object-cover"
+            sizes={IMAGE_SIZES}
+            fill
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-10">
+      <Carousel setApi={setApi} opts={{ loop: true }} className="mx-12">
+        <CarouselContent>
+          {images.map((image, i) => (
+            <CarouselItem key={image.url + i}>
+              <div className="relative h-[480px] overflow-hidden rounded-lg">
+                <Image
+                  src={image.url}
+                  alt={altFor(image, title)}
+                  className="object-cover"
+                  sizes={IMAGE_SIZES}
+                  fill
+                />
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+      <div className="mt-4 flex justify-center gap-2">
+        {images.map((image, i) => (
+          <button
+            key={"dot-" + image.url + i}
+            type="button"
+            aria-label={`Go to image ${i + 1}`}
+            aria-current={i === selected}
+            onClick={() => api?.scrollTo(i)}
+            className={cn(
+              "h-2 w-2 rounded-full transition-colors",
+              i === selected ? "bg-primary" : "bg-muted-foreground/40",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/class-gallery.tsx
+++ b/components/class-gallery.tsx
@@ -99,10 +99,10 @@ export function ClassGallery({
                 key={"dot-" + image.url + i}
                 type="button"
                 aria-label={`Go to image ${i + 1}`}
-                aria-current={i === selected}
+                aria-current={i === selected ? "true" : undefined}
                 onClick={() => api?.scrollTo(i)}
                 className={cn(
-                  "h-2 w-2 rounded-full transition-colors",
+                  "h-2 w-2 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                   i === selected ? "bg-primary" : "bg-muted-foreground/40",
                 )}
               />

--- a/components/class-gallery.tsx
+++ b/components/class-gallery.tsx
@@ -10,6 +10,13 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel"
+import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { cn } from "@/lib/utils"
 
 export type GalleryImage = { url: string; description: string }
@@ -29,6 +36,7 @@ export function ClassGallery({
 }) {
   const [api, setApi] = React.useState<CarouselApi>()
   const [selected, setSelected] = React.useState(0)
+  const [lightboxIndex, setLightboxIndex] = React.useState<number | null>(null)
 
   React.useEffect(() => {
     if (!api) return
@@ -42,10 +50,15 @@ export function ClassGallery({
 
   if (images.length === 0) return null
 
-  if (images.length === 1) {
-    return (
-      <div className="py-10">
-        <div className="relative h-[480px] overflow-hidden rounded-lg">
+  return (
+    <div className="py-10">
+      {images.length === 1 ? (
+        <button
+          type="button"
+          className="relative block h-[480px] w-full overflow-hidden rounded-lg"
+          aria-label={`View ${altFor(images[0], title)} full screen`}
+          onClick={() => setLightboxIndex(0)}
+        >
           <Image
             src={images[0].url}
             alt={altFor(images[0], title)}
@@ -53,47 +66,86 @@ export function ClassGallery({
             sizes={IMAGE_SIZES}
             fill
           />
-        </div>
-      </div>
-    )
-  }
-
-  return (
-    <div className="py-10">
-      <Carousel setApi={setApi} opts={{ loop: true }} className="mx-12">
-        <CarouselContent>
-          {images.map((image, i) => (
-            <CarouselItem key={image.url + i}>
-              <div className="relative h-[480px] overflow-hidden rounded-lg">
-                <Image
-                  src={image.url}
-                  alt={altFor(image, title)}
-                  className="object-cover"
-                  sizes={IMAGE_SIZES}
-                  fill
-                />
-              </div>
-            </CarouselItem>
-          ))}
-        </CarouselContent>
-        <CarouselPrevious />
-        <CarouselNext />
-      </Carousel>
-      <div className="mt-4 flex justify-center gap-2">
-        {images.map((image, i) => (
-          <button
-            key={"dot-" + image.url + i}
-            type="button"
-            aria-label={`Go to image ${i + 1}`}
-            aria-current={i === selected}
-            onClick={() => api?.scrollTo(i)}
-            className={cn(
-              "h-2 w-2 rounded-full transition-colors",
-              i === selected ? "bg-primary" : "bg-muted-foreground/40",
-            )}
-          />
-        ))}
-      </div>
+        </button>
+      ) : (
+        <>
+          <Carousel setApi={setApi} opts={{ loop: true }} className="mx-12">
+            <CarouselContent>
+              {images.map((image, i) => (
+                <CarouselItem key={image.url + i}>
+                  <button
+                    type="button"
+                    className="relative block h-[480px] w-full overflow-hidden rounded-lg"
+                    aria-label={`View ${altFor(image, title)} full screen`}
+                    onClick={() => setLightboxIndex(i)}
+                  >
+                    <Image
+                      src={image.url}
+                      alt={altFor(image, title)}
+                      className="object-cover"
+                      sizes={IMAGE_SIZES}
+                      fill
+                    />
+                  </button>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious />
+            <CarouselNext />
+          </Carousel>
+          <div className="mt-4 flex justify-center gap-2">
+            {images.map((image, i) => (
+              <button
+                key={"dot-" + image.url + i}
+                type="button"
+                aria-label={`Go to image ${i + 1}`}
+                aria-current={i === selected}
+                onClick={() => api?.scrollTo(i)}
+                className={cn(
+                  "h-2 w-2 rounded-full transition-colors",
+                  i === selected ? "bg-primary" : "bg-muted-foreground/40",
+                )}
+              />
+            ))}
+          </div>
+        </>
+      )}
+      <Dialog
+        open={lightboxIndex !== null}
+        onOpenChange={(open) => !open && setLightboxIndex(null)}
+      >
+        <DialogContent className="max-w-5xl border-0 bg-transparent p-0 shadow-none">
+          <VisuallyHidden asChild>
+            <DialogTitle>{title} gallery</DialogTitle>
+          </VisuallyHidden>
+          <VisuallyHidden asChild>
+            <DialogDescription>
+              Full-screen view of the {title} class gallery images
+            </DialogDescription>
+          </VisuallyHidden>
+          {lightboxIndex !== null && (
+            <Carousel opts={{ startIndex: lightboxIndex, loop: true }}>
+              <CarouselContent>
+                {images.map((image, i) => (
+                  <CarouselItem key={"lb-" + image.url + i}>
+                    <div className="relative h-[80vh]">
+                      <Image
+                        src={image.url}
+                        alt={altFor(image, title)}
+                        className="object-contain"
+                        sizes="100vw"
+                        fill
+                      />
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/docs/superpowers/plans/2026-07-03-gallery-rebuild.md
+++ b/docs/superpowers/plans/2026-07-03-gallery-rebuild.md
@@ -1,0 +1,467 @@
+# Class Gallery Rebuild Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the static 2-image class-page gallery with a full-width swipeable carousel (arrows + pagination dots) that shows *all* gallery images, plus a click-to-zoom lightbox.
+
+**Architecture:** Extract a new `"use client"` `ClassGallery` component that receives the gallery images and renders the carousel + lightbox, replacing the inline static grid in the server component `app/classes/[slug]/page.tsx`. Reuse the existing Embla `carousel.tsx` (arrows/keyboard built in; dots built here from `setApi`) and Radix `dialog.tsx` (dark overlay) for the lightbox.
+
+**Tech Stack:** Next.js 14 (App Router) + TypeScript, Vitest + React Testing Library (component tests), Embla Carousel 8, Radix Dialog, `next/image`, Tailwind/shadcn. npm; Prettier no-semicolons.
+
+## Assumptions & prerequisites
+
+1. **Vitest is already on `master`.** The duration-format work (which introduced Vitest — `vitest.config.mts` + the `test` script) has been squash-merged to `master`, so this branches cleanly off `master`. Task 1 below only adds the *component-testing* layer (React Testing Library) on top.
+2. **Embla + jsdom limitation.** Embla needs real layout, which jsdom lacks, so component tests verify *structure and behavior* (image count, alt text, dot count, controls present for 2+ images, lightbox opens on click, empty/single-image handling) — not actual scroll physics. Swipe/scroll motion is verified in the manual visual step.
+3. **Image data shape (from proto research):** each gallery image `Object` has `url`, `description` (documented as the alt-text source), `contentType` — **no width/height, captions, or blur data**. Aspect ratio is imposed by the container. Image count is unbounded (0 → N). All URLs are from the allowed `storage.googleapis.com/made-in-workshop/**` host.
+4. Gallery design (carousel + lightbox) was approved in the batch spec; no new design decisions are needed here.
+
+## Global Constraints
+
+- Show **all** `gallery.images`, not just the first two.
+- Alt text from each image's `description`; fall back to `masterClass.displayName` when `description` is empty. Never hardcode `"Gallery Image"`.
+- Graceful counts: **0 images → render nothing**; **1 image → static featured image, no arrows/dots**; **2+ → full carousel with arrows + dots**.
+- `next/image` with `object-cover` and a responsive `sizes` prop; only `storage.googleapis.com/made-in-workshop/**` is a permitted host.
+- The class page (`app/classes/[slug]/page.tsx`) is a server component (`export const dynamic = "force-dynamic"`) — all interactivity lives in the new `"use client"` child.
+- Styling: dark theme, gold/amber `--primary` (`43 97% 54%`), `rounded-lg`, shadcn tokens; match existing class-page conventions.
+- Path alias `@/*` → repo root. Code style: no semicolons. `npm run lint` clean; `npm run build` succeeds.
+
+---
+
+### Task 1: Add React Testing Library for component tests
+
+**Files:**
+- Modify: `cool-mint/package.json` (devDependencies)
+- Create: `cool-mint/vitest.setup.ts`
+- Modify: `cool-mint/vitest.config.mts` (register the setup file)
+- Test: `cool-mint/components/class-gallery.smoke.test.tsx` (temporary, removed in Task 2)
+
+**Interfaces:**
+- Consumes: Vitest from #2 (see Assumptions).
+- Produces: RTL (`render`, `screen`) + `@testing-library/jest-dom` matchers available in `*.test.tsx`; jsdom environment already set by #2's config.
+
+- [ ] **Step 1: Install RTL dev dependencies**
+
+Run (from `cool-mint/`):
+```bash
+npm install -D @testing-library/react@^16 @testing-library/user-event@^14 @testing-library/jest-dom@^6
+```
+
+- [ ] **Step 2: Create the Vitest setup file**
+
+Create `cool-mint/vitest.setup.ts`:
+```ts
+import "@testing-library/jest-dom/vitest"
+import { afterEach } from "vitest"
+import { cleanup } from "@testing-library/react"
+
+afterEach(() => {
+  cleanup()
+})
+```
+
+- [ ] **Step 3: Register the setup file in vitest.config.mts**
+
+In `cool-mint/vitest.config.mts`, add `setupFiles` to the `test` block:
+```ts
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["**/*.test.{ts,tsx}"],
+    exclude: ["node_modules", ".next"],
+  },
+```
+
+- [ ] **Step 4: Add a temporary smoke test that renders JSX via RTL**
+
+Create `cool-mint/components/class-gallery.smoke.test.tsx`:
+```tsx
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+describe("rtl setup", () => {
+  it("renders JSX and matches jest-dom matchers", () => {
+    render(<p>hello gallery</p>)
+    expect(screen.getByText("hello gallery")).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 5: Run the smoke test**
+
+Run: `npm test`
+Expected: PASS — confirms RTL renders and `toBeInTheDocument` (jest-dom) works.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json vitest.setup.ts vitest.config.mts components/class-gallery.smoke.test.tsx
+git commit -m "test: add react testing library for component tests"
+```
+
+---
+
+### Task 2: `ClassGallery` component — carousel + dots (TDD)
+
+**Files:**
+- Create: `cool-mint/components/class-gallery.tsx`
+- Test: `cool-mint/components/class-gallery.test.tsx`
+- Delete: `cool-mint/components/class-gallery.smoke.test.tsx`
+
+**Interfaces:**
+- Consumes: RTL (Task 1); `Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext` from `@/components/ui/carousel`; `next/image`.
+- Produces: `export type GalleryImage = { url: string; description: string }` and `export function ClassGallery(props: { images: GalleryImage[]; title: string }): JSX.Element | null`. Later tasks add the lightbox to this same component.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `cool-mint/components/class-gallery.test.tsx`:
+```tsx
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ClassGallery } from "@/components/class-gallery"
+
+const img = (n: number, desc = "") => ({
+  url: `https://storage.googleapis.com/made-in-workshop/g${n}.jpg`,
+  description: desc,
+})
+
+describe("ClassGallery", () => {
+  it("renders nothing when there are no images", () => {
+    const { container } = render(<ClassGallery images={[]} title="Woodworking 101" />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders a single image without carousel controls", () => {
+    render(<ClassGallery images={[img(1, "A lathe")]} title="Woodworking 101" />)
+    expect(screen.getByAltText("A lathe")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /previous|next/i })).toBeNull()
+  })
+
+  it("renders all images and carousel controls for 2+ images", () => {
+    render(
+      <ClassGallery
+        images={[img(1, "A lathe"), img(2), img(3, "A chisel")]}
+        title="Woodworking 101"
+      />,
+    )
+    // all three images present
+    expect(screen.getByAltText("A lathe")).toBeInTheDocument()
+    expect(screen.getByAltText("A chisel")).toBeInTheDocument()
+    // empty description falls back to the class title
+    expect(screen.getAllByAltText("Woodworking 101").length).toBe(1)
+    // arrows present
+    expect(screen.getByRole("button", { name: /previous/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument()
+    // one pagination dot per image
+    expect(screen.getAllByRole("button", { name: /go to image/i })).toHaveLength(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — cannot resolve `@/components/class-gallery`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `cool-mint/components/class-gallery.tsx`:
+```tsx
+"use client"
+
+import * as React from "react"
+import Image from "next/image"
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from "@/components/ui/carousel"
+import { cn } from "@/lib/utils"
+
+export type GalleryImage = { url: string; description: string }
+
+const IMAGE_SIZES = "(max-width: 768px) 100vw, (max-width: 1280px) 90vw, 1200px"
+
+function altFor(image: GalleryImage, title: string): string {
+  return image.description.trim() || title
+}
+
+export function ClassGallery({
+  images,
+  title,
+}: {
+  images: GalleryImage[]
+  title: string
+}) {
+  const [api, setApi] = React.useState<CarouselApi>()
+  const [selected, setSelected] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!api) return
+    setSelected(api.selectedScrollSnap())
+    const onSelect = () => setSelected(api.selectedScrollSnap())
+    api.on("select", onSelect)
+    return () => {
+      api.off("select", onSelect)
+    }
+  }, [api])
+
+  if (images.length === 0) return null
+
+  if (images.length === 1) {
+    return (
+      <div className="py-10">
+        <div className="relative h-[480px] overflow-hidden rounded-lg">
+          <Image
+            src={images[0].url}
+            alt={altFor(images[0], title)}
+            className="object-cover"
+            sizes={IMAGE_SIZES}
+            fill
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="py-10">
+      <Carousel setApi={setApi} opts={{ loop: true }} className="mx-12">
+        <CarouselContent>
+          {images.map((image, i) => (
+            <CarouselItem key={image.url + i}>
+              <div className="relative h-[480px] overflow-hidden rounded-lg">
+                <Image
+                  src={image.url}
+                  alt={altFor(image, title)}
+                  className="object-cover"
+                  sizes={IMAGE_SIZES}
+                  fill
+                />
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious />
+        <CarouselNext />
+      </Carousel>
+      <div className="mt-4 flex justify-center gap-2">
+        {images.map((image, i) => (
+          <button
+            key={"dot-" + image.url + i}
+            type="button"
+            aria-label={`Go to image ${i + 1}`}
+            aria-current={i === selected}
+            onClick={() => api?.scrollTo(i)}
+            className={cn(
+              "h-2 w-2 rounded-full transition-colors",
+              i === selected ? "bg-primary" : "bg-muted-foreground/40",
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Delete the temporary smoke test**
+
+Run: `rm components/class-gallery.smoke.test.tsx`
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS — all `ClassGallery` cases green. (Note: `CarouselPrevious`/`CarouselNext` render with accessible names "Previous slide"/"Next slide" from `carousel.tsx`; the `/previous/i` and `/next/i` matchers rely on that.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/class-gallery.tsx components/class-gallery.test.tsx components/class-gallery.smoke.test.tsx
+git commit -m "feat: add ClassGallery carousel component with pagination dots"
+```
+
+---
+
+### Task 3: Click-to-zoom lightbox (TDD)
+
+**Files:**
+- Modify: `cool-mint/components/class-gallery.tsx`
+- Modify: `cool-mint/components/class-gallery.test.tsx`
+
+**Interfaces:**
+- Consumes: `Dialog, DialogContent` from `@/components/ui/dialog`; `@testing-library/user-event`.
+- Produces: clicking any featured/carousel image opens a full-screen `Dialog` lightbox containing a carousel of all images, opened at the clicked index.
+
+- [ ] **Step 1: Add the failing lightbox test**
+
+Append to `cool-mint/components/class-gallery.test.tsx` (add `import userEvent from "@testing-library/user-event"` at the top):
+```tsx
+  it("opens a lightbox dialog when an image is clicked", async () => {
+    const user = userEvent.setup()
+    render(
+      <ClassGallery
+        images={[img(1, "A lathe"), img(2, "A chisel")]}
+        title="Woodworking 101"
+      />,
+    )
+    expect(screen.queryByRole("dialog")).toBeNull()
+    await user.click(screen.getAllByAltText("A lathe")[0])
+    expect(await screen.findByRole("dialog")).toBeInTheDocument()
+  })
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — no dialog opens on click (images are not yet interactive).
+
+- [ ] **Step 3: Implement the lightbox**
+
+In `cool-mint/components/class-gallery.tsx`:
+
+Add imports:
+```tsx
+import { Dialog, DialogContent } from "@/components/ui/dialog"
+```
+
+Add lightbox state inside the component (near the other `useState`s):
+```tsx
+  const [lightboxIndex, setLightboxIndex] = React.useState<number | null>(null)
+```
+
+Wrap each carousel image (and the single-image case) so the image is a button that sets `lightboxIndex`. For the multi-image `CarouselItem` image container, wrap the `<div className="relative h-[480px] ...">` in:
+```tsx
+                <button
+                  type="button"
+                  className="relative block h-[480px] w-full overflow-hidden rounded-lg"
+                  aria-label={`View ${altFor(image, title)} full screen`}
+                  onClick={() => setLightboxIndex(i)}
+                >
+                  <Image
+                    src={image.url}
+                    alt={altFor(image, title)}
+                    className="object-cover"
+                    sizes={IMAGE_SIZES}
+                    fill
+                  />
+                </button>
+```
+(Apply the same button-wrapping to the single-image branch with `onClick={() => setLightboxIndex(0)}`.)
+
+Add the lightbox Dialog at the end of the returned JSX (before the closing wrapper), rendering a carousel of all images starting at `lightboxIndex`:
+```tsx
+      <Dialog
+        open={lightboxIndex !== null}
+        onOpenChange={(open) => !open && setLightboxIndex(null)}
+      >
+        <DialogContent className="max-w-5xl border-0 bg-transparent p-0 shadow-none">
+          {lightboxIndex !== null && (
+            <Carousel opts={{ startIndex: lightboxIndex, loop: true }}>
+              <CarouselContent>
+                {images.map((image, i) => (
+                  <CarouselItem key={"lb-" + image.url + i}>
+                    <div className="relative h-[80vh]">
+                      <Image
+                        src={image.url}
+                        alt={altFor(image, title)}
+                        className="object-contain"
+                        sizes="100vw"
+                        fill
+                      />
+                    </div>
+                  </CarouselItem>
+                ))}
+              </CarouselContent>
+              <CarouselPrevious />
+              <CarouselNext />
+            </Carousel>
+          )}
+        </DialogContent>
+      </Dialog>
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm test`
+Expected: PASS — all prior cases plus the lightbox-open case.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/class-gallery.tsx components/class-gallery.test.tsx
+git commit -m "feat: add click-to-zoom lightbox to ClassGallery"
+```
+
+---
+
+### Task 4: Wire `ClassGallery` into the class page
+
+**Files:**
+- Modify: `cool-mint/app/classes/[slug]/page.tsx:157-179` (replace static grid), and imports (add `ClassGallery`, remove now-unused `Image` if no other use remains in the file — verify first).
+
+**Interfaces:**
+- Consumes: `ClassGallery`, `GalleryImage` from `@/components/class-gallery`.
+- Produces: the class page renders the new gallery for all `masterClass.gallery.images`.
+
+- [ ] **Step 1: Replace the static grid**
+
+Add the import near the top of `cool-mint/app/classes/[slug]/page.tsx`:
+```tsx
+import { ClassGallery } from "@/components/class-gallery"
+```
+Replace the whole `{/* Class Images */}` block (lines 157–179) with:
+```tsx
+          {/* Class Images */}
+          <ClassGallery
+            images={masterClass.gallery.images.map((i) => ({
+              url: i.url,
+              description: i.description,
+            }))}
+            title={masterClass.displayName}
+          />
+```
+
+- [ ] **Step 2: Check whether `Image` is still used in page.tsx**
+
+Run: `grep -n "next/image\|<Image" app/classes/[slug]/page.tsx`
+If no `<Image` usages remain, remove the now-unused `import Image from "next/image"` line. If other usages remain, leave the import.
+
+- [ ] **Step 3: Verify build and lint**
+
+Run: `npm run lint && npm run build`
+Expected: lint clean (no unused-import errors); build succeeds.
+
+- [ ] **Step 4: Manual visual verification** (controller/human — needs cool-mint dev + made-in-workshop backend with a class that has 3+ gallery images)
+
+Load a class page and confirm: all gallery images appear in a full-width carousel; arrows and dots work; dots highlight the current image; clicking an image opens the full-screen lightbox at that image; the lightbox swipes/arrows through all images and closes on overlay/Esc; a class with exactly 1 image shows a single static image (no controls); a class with 0 images shows no gallery block. Check mobile width too.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/classes/[slug]/page.tsx
+git commit -m "feat: replace static class gallery with carousel + lightbox"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (#6 section):**
+- Full-width swipeable carousel showing ALL images → Task 2. ✅
+- Arrows (reused) + pagination dots (built from `setApi`) → Task 2. ✅
+- Click-to-zoom lightbox via Dialog + synced carousel at clicked index → Task 3. ✅
+- Real alt from `description`, fallback to `displayName` → Task 2 (`altFor`) + tested. ✅
+- Responsive `sizes`, `object-cover`, container-imposed aspect ratio → Task 2. ✅
+- Graceful 0/1/2+ counts → Task 2 (tested) . ✅
+- `"use client"` child of the server page → Tasks 2 & 4. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code. The two human-judgment points (unused-import check, manual visual) are explicit verification steps, not placeholders. ✅
+
+**3. Type consistency:** `GalleryImage = { url, description }` and `ClassGallery({ images, title })` defined in Task 2, consumed unchanged in Tasks 3 and 4; `CarouselApi` imported from `@/components/ui/carousel` (it is exported there). Page maps proto `Object[]` → `GalleryImage[]` in Task 4. ✅
+
+**Resolved decisions:**
+- Vitest prerequisite: satisfied — the duration-format work is merged to `master`, so Vitest is present; this branches off `master`.
+- Embla-in-jsdom testing scope (assumption #2): accepted — component tests cover structure/behavior (counts, alt, dots, lightbox open, empty/single handling); scroll physics is verified in the manual visual step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,9 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.13",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/lodash": "^4.17.6",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -93,6 +96,13 @@
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -4441,6 +4451,96 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.19.0.tgz",
@@ -4481,6 +4581,14 @@
       "dependencies": {
         "@types/estree": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6218,6 +6326,13 @@
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
       "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -6561,6 +6676,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/domready": {
       "version": "0.2.13",
@@ -8399,6 +8522,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9390,6 +9523,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -10285,6 +10429,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-svg-data-uri": {
@@ -12401,6 +12555,44 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -12744,6 +12936,20 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reduce-css-calc": {
@@ -13660,6 +13866,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-tabs": "^1.0.4",
+        "@radix-ui/react-visually-hidden": "^1.0.3",
         "@tailwindcss/forms": "^0.5.7",
         "@tanstack/react-table": "^8.17.3",
         "@types/classnames": "^2.3.1",
@@ -3926,6 +3927,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.3.tgz",
       "integrity": "sha512-D4w41yN5YRKtu464TLnByKzMDG/JlMPHtfZgQAu9v6mNakUqGUI9vUrfQKz8NK41VMm/xbZbh76NUTVtIYqOMA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.10",
         "@radix-ui/react-primitive": "1.0.3"

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.13",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/lodash": "^4.17.6",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-tabs": "^1.0.4",
+    "@radix-ui/react-visually-hidden": "^1.0.3",
     "@tailwindcss/forms": "^0.5.7",
     "@tanstack/react-table": "^8.17.3",
     "@types/classnames": "^2.3.1",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
     environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.test.{ts,tsx}"],
     exclude: ["node_modules", ".next"],
   },

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest"
+import { afterEach } from "vitest"
+import { cleanup } from "@testing-library/react"
+
+afterEach(() => {
+  cleanup()
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,6 +2,23 @@ import "@testing-library/jest-dom/vitest"
 import { afterEach, vi } from "vitest"
 import { cleanup } from "@testing-library/react"
 
+// Suppress known-benign next/image fetchPriority warning (React@18 + next@14.1 quirk).
+// Silently drop errors containing "fetchPriority"; all other errors pass through unchanged.
+const originalError = console.error
+const originalWarn = console.warn
+console.error = (...args: any[]) => {
+  if (args.some((arg) => typeof arg === "string" && arg.includes("fetchPriority"))) {
+    return
+  }
+  originalError(...args)
+}
+console.warn = (...args: any[]) => {
+  if (args.some((arg) => typeof arg === "string" && arg.includes("fetchPriority"))) {
+    return
+  }
+  originalWarn(...args)
+}
+
 // jsdom has no layout engine and doesn't implement matchMedia or
 // IntersectionObserver, both of which Embla (used by components/ui/carousel)
 // reads on init regardless of viewport size. Stub them so carousel-based
@@ -20,6 +37,7 @@ Object.defineProperty(window, "matchMedia", {
   })),
 })
 
+// Non-firing mocks: constructors and no-op methods only; callbacks are never invoked.
 class MockIntersectionObserver {
   observe = vi.fn()
   unobserve = vi.fn()

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,6 +1,38 @@
 import "@testing-library/jest-dom/vitest"
-import { afterEach } from "vitest"
+import { afterEach, vi } from "vitest"
 import { cleanup } from "@testing-library/react"
+
+// jsdom has no layout engine and doesn't implement matchMedia or
+// IntersectionObserver, both of which Embla (used by components/ui/carousel)
+// reads on init regardless of viewport size. Stub them so carousel-based
+// components can mount under jsdom.
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+class MockIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+
+class MockResizeObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+vi.stubGlobal("ResizeObserver", MockResizeObserver)
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## What & why

June client change request **item 6** ("double-check the image gallery scroller"). The class-page gallery was a static grid that only ever rendered the first 2 images (silently dropping the rest), with hardcoded alt text and no interaction. This rebuilds it as a proper gallery.

## Changes

- **New `ClassGallery` component** (`components/class-gallery.tsx`, `"use client"`):
  - Full-width **Embla carousel** showing **all** gallery images, with arrows + **pagination dots** (built from `setApi`, with keyboard focus ring + `aria-current`).
  - **Click-to-zoom lightbox** via Radix Dialog, opening at the clicked image, with a visually-hidden `DialogTitle`/`DialogDescription` for accessibility.
  - Graceful counts: 0 images -> nothing; 1 -> static image (no controls); 2+ -> carousel.
  - Real alt text from each image's `description`, falling back to the class display name (no more hardcoded "Gallery Image"); `next/image` with `object-cover` + responsive `sizes`.
- **Wired into the class page**, replacing the static grid (`app/classes/[slug]/page.tsx`).
- **Test tooling:** adds React Testing Library on top of Vitest; jsdom shims for Embla (matchMedia/IntersectionObserver/ResizeObserver) and a targeted filter for the known-benign `next/image` fetchPriority warning. New dep: `@radix-ui/react-visually-hidden`.

## Testing

- `npm test` -> 10/10 passing (component structure/behavior: counts, alt fallback, dot count, lightbox opens)
- `npm run lint` -> clean (only two pre-existing unrelated warnings)
- `npm run build` -> succeeds

## ⚠️ Required before merge — manual browser check

jsdom cannot drive Embla's real layout, so two behaviors are verified by code review but **not** by the automated tests and MUST be eyeballed in a browser before merging:

- [ ] Clicking image N opens the lightbox **at image N** (`startIndex`)
- [ ] Arrows / swipe / dots navigate, and the active dot highlights in sync
- [ ] A class with **3+ images**, a **1-image** class, and a **0-image** class all render correctly
- [ ] Mobile width looks right

Generated with Claude Code