### PR TITLE
feat: inline session selection on the class page

### DIFF
--- a/app/classes/[slug]/page.tsx
+++ b/app/classes/[slug]/page.tsx
@@ -129,14 +129,12 @@ export default async function Page({ params }: ClassPageProps) {
             {/* Right Column - Booking Card */}
             <div className="lg:col-span-1">
               <BookingCard
-                masterClassName={masterClass.name}
-                displayName={masterClass.displayName}
                 standardPrice={masterClass.standardPrice}
                 difficulty={masterClass.difficulty}
                 duration={masterClass.duration}
                 maxAttendees={totalSpots}
                 spotsFilled={spotsFilled}
-                firstAvailableSession={firstAvailableSession}
+                sessions={masterClassSessions}
                 sessionInfos={sessionInfos}
               />
             </div>

--- a/app/classes/[slug]/page.tsx
+++ b/app/classes/[slug]/page.tsx
@@ -176,18 +176,22 @@ export default async function Page({ params }: ClassPageProps) {
             </div>
           )}
 
-          {/* Choose Your Date */}
-          <hr className="my-6 border-muted-foreground/20" />
-          <div id="choose-date">
-            <h2 className="py-3 font-helvetica text-lg font-bold text-muted-foreground">
-              Choose Your Date
-            </h2>
-          </div>
-          <div>
-            <Suspense fallback={<UpcomingClassesLoader />}>
-              <UpcomingClasses masterClass={masterClass.name} />
-            </Suspense>
-          </div>
+          {masterClassSessions.length > 0 && (
+            <>
+              {/* Choose Your Date */}
+              <hr className="my-6 border-muted-foreground/20" />
+              <div id="choose-date">
+                <h2 className="py-3 font-helvetica text-lg font-bold text-muted-foreground">
+                  Choose Your Date
+                </h2>
+              </div>
+              <div>
+                <Suspense fallback={<UpcomingClassesLoader />}>
+                  <UpcomingClasses masterClass={masterClass.name} />
+                </Suspense>
+              </div>
+            </>
+          )}
 
           {/* Related Classes */}
           <hr className="my-6 border-muted-foreground/20" />

--- a/components/base/upcomingWorkshops.tsx
+++ b/components/base/upcomingWorkshops.tsx
@@ -58,7 +58,7 @@ export const UpcomingWorkshops: React.FC<UpcomingWorkshopsProps> = ({
         </div>
 
         <div className="px-0 xl:px-0 2xl:px-40">
-          {single && (
+          {single && masterClasses[0] && (
             <CardTitle className="mb-4 text-foreground">
               {masterClasses[0].displayName}
             </CardTitle>

--- a/components/booking-card.tsx
+++ b/components/booking-card.tsx
@@ -1,108 +1,34 @@
 "use client"
 
-import { bookSessions } from "@/app/classes/actions"
-import { useCart } from "@/contexts/cart"
-import { useUser } from "@/contexts/user"
 import { Session } from "@/lib/fusion/masterClass/session.pb"
 import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
-import { parseError } from "@/lib/util/error"
 import { formatDuration } from "@/lib/util/format-duration"
 import { moneyFormatter } from "@/lib/util/money-formatter"
-import { format } from "date-fns"
-import { Calendar, Clock, MapPin, SignalHigh, Users } from "lucide-react"
-import { usePathname, useRouter } from "next/navigation"
+import { Clock, MapPin, SignalHigh, Users } from "lucide-react"
 import React from "react"
-import { toast } from "sonner"
-import { SessionPicker } from "./session-picker"
-import { Spinner } from "./ui/spinner"
+import { InlineSessionSelector } from "./inline-session-selector"
 
 interface BookingCardProps {
-  masterClassName: string
-  displayName: string
   standardPrice: bigint
   difficulty: string
   duration: number
   maxAttendees: number
   spotsFilled: number
-  firstAvailableSession?: Session
+  sessions: Session[]
   sessionInfos?: SessionInfo[]
 }
 
 export const BookingCard: React.FC<BookingCardProps> = ({
-  masterClassName,
-  displayName,
   standardPrice,
   difficulty,
   duration,
   maxAttendees,
   spotsFilled,
-  firstAvailableSession,
+  sessions,
   sessionInfos,
 }) => {
-  const router = useRouter()
-  const user = useUser()
-  const cartContext = useCart()
-  const pathname = usePathname()
-  const [loading, setLoading] = React.useState(false)
-  const [multiPickerOpen, setMultiPickerOpen] = React.useState(false)
-
   const spotsRemaining = maxAttendees - spotsFilled
   const fillPercentage = (spotsFilled / maxAttendees) * 100
-  const hasAdditionalSessions = sessionInfos
-    ? sessionInfos.some((si) => si.session !== firstAvailableSession?.name)
-    : false
-
-  const handleReserveSpot = async () => {
-    if (!firstAvailableSession) {
-      toast.error("No available sessions")
-      return
-    }
-
-    // ensure the user is logged in
-    if (!user) {
-      const loginUrl = new URL("/login", window.location.origin)
-      if (pathname !== "/") {
-        loginUrl.searchParams.set("redirect", pathname.slice(1))
-      } else {
-        loginUrl.searchParams.set("redirect", "#upcoming-sessions")
-      }
-
-      toast("Please login to book your spot", {
-        action: {
-          label: "Login",
-          onClick: () => router.push(loginUrl.toString()),
-        },
-      })
-      return
-    }
-
-    try {
-      setLoading(true)
-      const response = await bookSessions({
-        items: [{ session: firstAvailableSession.name, quantity: 1 }],
-      })
-
-      if (response.cart) {
-        cartContext.setCart(response.cart)
-      }
-
-      setLoading(false)
-
-      if (response.errors.length > 0) {
-        toast.error(response.errors[0].reason)
-        return
-      }
-
-      toast.success("Added to cart")
-      router.push("/cart")
-    } catch (e: unknown) {
-      setLoading(false)
-      toast.error("Failed to add to cart: " + parseError(e))
-      console.error("Add to cart failed:", e)
-    }
-  }
-
-  const soldOut = !firstAvailableSession || spotsRemaining <= 0
 
   return (
     <div
@@ -175,63 +101,19 @@ export const BookingCard: React.FC<BookingCardProps> = ({
         </div>
       </div>
 
-      {/* Next Session Date */}
-      {firstAvailableSession && (
-        <div className="mt-4 flex items-start gap-3">
-          <Calendar className="mt-0.5 h-5 w-5 text-primary" />
-          <div>
-            <p className="text-xs text-muted-foreground">Next Session</p>
-            <p className="font-helvetica font-medium text-foreground">
-              {format(new Date(firstAvailableSession.date), "EEEE, d MMMM yyyy 'at' HH:mm")}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* CTA Button */}
-      {soldOut ? (
-        <div className="mt-6 w-full rounded-lg bg-muted py-3 text-center font-helvetica font-semibold text-muted-foreground">
-          Sold Out
-        </div>
-      ) : (
-        <button
-          onClick={handleReserveSpot}
-          disabled={loading}
-          className="relative mt-6 w-full rounded-lg bg-primary py-3 font-helvetica font-semibold text-background transition-colors hover:bg-primary/90 disabled:opacity-70"
-        >
-          Reserve Your Spot
-          {loading && (
-            <Spinner className="absolute right-4 top-1/2 h-4 w-4 -translate-y-1/2 text-background" />
-          )}
-        </button>
-      )}
-
-      {/* Multi-session booking */}
-      {!soldOut && hasAdditionalSessions && (
-        <button
-          onClick={() => setMultiPickerOpen(true)}
-          className="mt-3 w-full text-center text-sm text-primary underline-offset-2 hover:underline"
-        >
-          Book multiple sessions
-        </button>
-      )}
+      {/* Inline session selection + booking CTA */}
+      <InlineSessionSelector
+        maxAttendees={maxAttendees}
+        standardPrice={standardPrice}
+        sessions={sessions}
+        sessionInfos={sessionInfos}
+        maxSelections={5}
+      />
 
       {/* Cancellation Policy */}
       <p className="mt-4 text-center text-xs text-white/80">
         Free cancellation up to 48 hours before class
       </p>
-
-      <SessionPicker
-        masterClassName={masterClassName}
-        masterClassDisplayName={displayName}
-        maxAttendees={maxAttendees}
-        standardPrice={standardPrice}
-        open={multiPickerOpen}
-        onOpenChange={setMultiPickerOpen}
-        multi
-        maxSelections={5}
-        sessionInfos={sessionInfos}
-      />
     </div>
   )
 }

--- a/components/inline-session-selector.tsx
+++ b/components/inline-session-selector.tsx
@@ -9,6 +9,8 @@ import { parseError } from "@/lib/util/error"
 import { moneyFormatter } from "@/lib/util/money-formatter"
 import {
   firstSelectableSession,
+  formatSessionDate,
+  formatSessionTime,
   infoForSession,
   isSessionBooked,
   isSessionFull,
@@ -31,19 +33,6 @@ interface InlineSessionSelectorProps {
   sessionInfos?: SessionInfo[]
   maxSelections?: number
 }
-
-const formatDate = (dateStr: string) =>
-  new Date(dateStr).toLocaleDateString("en-ZA", {
-    weekday: "short",
-    day: "numeric",
-    month: "short",
-  })
-
-const formatTime = (dateStr: string) =>
-  new Date(dateStr).toLocaleTimeString("en-ZA", {
-    hour: "2-digit",
-    minute: "2-digit",
-  })
 
 export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
   maxAttendees,
@@ -166,11 +155,11 @@ export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
                     <div className="flex items-center gap-2">
                       <Calendar className="h-4 w-4 text-primary" />
                       <span className="font-medium text-foreground">
-                        {formatDate(session.date)}
+                        {formatSessionDate(session.date)}
                       </span>
                       <Clock className="ml-2 h-4 w-4 text-primary" />
                       <span className="text-foreground">
-                        {formatTime(session.date)}
+                        {formatSessionTime(session.date)}
                       </span>
                     </div>
                     <div className="mt-1 flex items-center gap-2">

--- a/components/inline-session-selector.tsx
+++ b/components/inline-session-selector.tsx
@@ -17,13 +17,13 @@ import {
   spotsLeftFor,
   toggleSelection,
 } from "@/lib/util/session-selection"
-import { Calendar, Clock, Users } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Calendar, Check, Clock, Users } from "lucide-react"
 import { usePathname, useRouter } from "next/navigation"
 import React from "react"
 import { toast } from "sonner"
 import { Badge } from "./ui/badge"
 import { Button } from "./ui/button"
-import { Checkbox } from "./ui/checkbox"
 import { Spinner } from "./ui/spinner"
 
 interface InlineSessionSelectorProps {
@@ -136,6 +136,7 @@ export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
                 key={session.name}
                 type="button"
                 disabled={isDisabled}
+                aria-pressed={isSelected}
                 onClick={() => toggleSession(session)}
                 className={`w-full rounded-lg border p-3 text-left transition-colors ${
                   isSelected
@@ -146,11 +147,17 @@ export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
                 }`}
               >
                 <div className="flex items-center gap-3">
-                  <Checkbox
-                    checked={isSelected}
-                    disabled={isDisabled}
-                    className="pointer-events-none"
-                  />
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border",
+                      isSelected
+                        ? "border-primary bg-primary text-primary-foreground"
+                        : "border-primary/50",
+                    )}
+                  >
+                    {isSelected && <Check className="h-3 w-3" />}
+                  </span>
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <Calendar className="h-4 w-4 text-primary" />

--- a/components/inline-session-selector.tsx
+++ b/components/inline-session-selector.tsx
@@ -1,0 +1,228 @@
+"use client"
+
+import { bookSessions } from "@/app/classes/actions"
+import { useCart } from "@/contexts/cart"
+import { useUser } from "@/contexts/user"
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+import { parseError } from "@/lib/util/error"
+import { moneyFormatter } from "@/lib/util/money-formatter"
+import {
+  firstSelectableSession,
+  infoForSession,
+  isSessionBooked,
+  isSessionFull,
+  spotsLeftFor,
+  toggleSelection,
+} from "@/lib/util/session-selection"
+import { Calendar, Clock, Users } from "lucide-react"
+import { usePathname, useRouter } from "next/navigation"
+import React from "react"
+import { toast } from "sonner"
+import { Badge } from "./ui/badge"
+import { Button } from "./ui/button"
+import { Checkbox } from "./ui/checkbox"
+import { Spinner } from "./ui/spinner"
+
+interface InlineSessionSelectorProps {
+  maxAttendees: number
+  standardPrice: bigint
+  sessions: Session[]
+  sessionInfos?: SessionInfo[]
+  maxSelections?: number
+}
+
+const formatDate = (dateStr: string) =>
+  new Date(dateStr).toLocaleDateString("en-ZA", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  })
+
+const formatTime = (dateStr: string) =>
+  new Date(dateStr).toLocaleTimeString("en-ZA", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+
+export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
+  maxAttendees,
+  standardPrice,
+  sessions,
+  sessionInfos,
+  maxSelections = 5,
+}) => {
+  const router = useRouter()
+  const user = useUser()
+  const cartContext = useCart()
+  const pathname = usePathname()
+  const infos = sessionInfos ?? []
+  const [selected, setSelected] = React.useState<Session[]>(() => {
+    const first = firstSelectableSession(sessions, infos, maxAttendees)
+    return first ? [first] : []
+  })
+  const [loading, setLoading] = React.useState(false)
+
+  const toggleSession = (session: Session) => {
+    setSelected((prev) => toggleSelection(prev, session, maxSelections))
+  }
+
+  const handleAddToCart = async () => {
+    if (!user) {
+      const loginUrl = new URL("/login", window.location.origin)
+      if (pathname !== "/") {
+        loginUrl.searchParams.set("redirect", pathname.slice(1))
+      }
+      toast("Please login to book your spot", {
+        action: {
+          label: "Login",
+          onClick: () => router.push(loginUrl.toString()),
+        },
+      })
+      return
+    }
+
+    if (selected.length === 0) return
+
+    try {
+      setLoading(true)
+      const response = await bookSessions({
+        items: selected.map((s) => ({ session: s.name, quantity: 1 })),
+      })
+
+      if (response.cart) {
+        cartContext.setCart(response.cart)
+      }
+
+      setLoading(false)
+
+      if (response.errors.length > 0 && response.booked.length > 0) {
+        toast.warning(
+          `Added ${response.booked.length} session${response.booked.length > 1 ? "s" : ""} to cart. ${response.errors.length} failed: ${response.errors.map((e) => e.reason).join(", ")}`,
+        )
+      } else if (response.errors.length > 0) {
+        toast.error(response.errors.map((e) => e.reason).join(", "))
+        return
+      } else {
+        toast.success(
+          response.booked.length === 1
+            ? "Added to cart"
+            : `Added ${response.booked.length} sessions to cart`,
+        )
+      }
+      router.push("/cart")
+    } catch (e: unknown) {
+      setLoading(false)
+      toast.error("Failed to add to cart: " + parseError(e))
+    }
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="font-helvetica font-semibold text-foreground">
+          Select sessions
+        </p>
+        <span className="text-xs text-muted-foreground">
+          up to {maxSelections}
+        </span>
+      </div>
+
+      {sessions.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No upcoming sessions available
+        </p>
+      ) : (
+        <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
+          {sessions.map((session) => {
+            const info = infoForSession(session, infos)
+            const spotsLeft = spotsLeftFor(session, info, maxAttendees)
+            const isFull = isSessionFull(session, info, maxAttendees)
+            const isBooked = isSessionBooked(info)
+            const isSelected = selected.some((s) => s.name === session.name)
+            const isDisabled = isFull || isBooked
+
+            return (
+              <button
+                key={session.name}
+                type="button"
+                disabled={isDisabled}
+                onClick={() => toggleSession(session)}
+                className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                  isSelected
+                    ? "border-primary bg-primary/10"
+                    : isDisabled
+                      ? "cursor-not-allowed border-muted/20 opacity-50"
+                      : "border-muted/20 hover:border-primary/50"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    checked={isSelected}
+                    disabled={isDisabled}
+                    className="pointer-events-none"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-4 w-4 text-primary" />
+                      <span className="font-medium text-foreground">
+                        {formatDate(session.date)}
+                      </span>
+                      <Clock className="ml-2 h-4 w-4 text-primary" />
+                      <span className="text-foreground">
+                        {formatTime(session.date)}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <Users className="h-3 w-3 text-muted-foreground" />
+                      {isBooked ? (
+                        <Badge variant="secondary" className="text-xs">
+                          Already Booked
+                        </Badge>
+                      ) : isFull ? (
+                        <Badge variant="destructive" className="text-xs">
+                          Full
+                        </Badge>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          {spotsLeft} spots left
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {selected.length > 0 && (
+        <div className="mt-4 space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              {selected.length} session{selected.length > 1 ? "s" : ""} selected
+            </span>
+            <span className="font-semibold text-primary">
+              {moneyFormatter.format(
+                (standardPrice * BigInt(selected.length)) / 100n,
+              )}
+            </span>
+          </div>
+          <Button
+            onClick={handleAddToCart}
+            disabled={loading}
+            className="relative w-full"
+          >
+            {selected.length > 1
+              ? `Add ${selected.length} Sessions to Cart`
+              : "Add to Cart"}
+            {loading && (
+              <Spinner className="absolute right-4 h-4 w-4 text-background" />
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/session-picker.tsx
+++ b/components/session-picker.tsx
@@ -7,13 +7,20 @@ import { Session } from "@/lib/fusion/masterClass/session.pb"
 import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
 import { moneyFormatter } from "@/lib/util/money-formatter"
 import { parseError } from "@/lib/util/error"
+import {
+  formatSessionDate,
+  formatSessionTime,
+  infoForSession,
+  isSessionBooked,
+  isSessionFull,
+  spotsLeftFor,
+} from "@/lib/util/session-selection"
 import { Calendar, Clock, Users } from "lucide-react"
 import { usePathname, useRouter } from "next/navigation"
 import React, { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Badge } from "./ui/badge"
 import { Button } from "./ui/button"
-import { Checkbox } from "./ui/checkbox"
 import {
   Dialog,
   DialogContent,
@@ -29,8 +36,6 @@ interface SessionPickerProps {
   standardPrice: bigint
   open: boolean
   onOpenChange: (open: boolean) => void
-  multi?: boolean
-  maxSelections?: number
   sessionInfos?: SessionInfo[]
 }
 
@@ -41,8 +46,6 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
   standardPrice,
   open,
   onOpenChange,
-  multi = false,
-  maxSelections = 5,
   sessionInfos,
 }) => {
   const router = useRouter()
@@ -78,11 +81,9 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
 
   const toggleSession = (session: Session) => {
     if (selected.find((s) => s.name === session.name)) {
-      setSelected(selected.filter((s) => s.name !== session.name))
-    } else if (!multi) {
+      setSelected([])
+    } else {
       setSelected([session])
-    } else if (selected.length < maxSelections) {
-      setSelected([...selected, session])
     }
   }
 
@@ -139,33 +140,15 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
     }
   }
 
-  const formatDate = (dateStr: string) => {
-    const date = new Date(dateStr)
-    return date.toLocaleDateString("en-ZA", {
-      weekday: "short",
-      day: "numeric",
-      month: "short",
-    })
-  }
-
-  const formatTime = (dateStr: string) => {
-    const date = new Date(dateStr)
-    return date.toLocaleTimeString("en-ZA", {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  }
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[80vh] overflow-y-auto bg-[#1a1a1a] sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="font-helvetica text-foreground">
-            {multi ? "Select Sessions" : "Choose a Date"}
+            Choose a Date
           </DialogTitle>
           <p className="text-sm text-muted-foreground">
             {masterClassDisplayName}
-            {multi && ` — select up to ${maxSelections}`}
           </p>
         </DialogHeader>
 
@@ -180,14 +163,10 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
         ) : (
           <div className="space-y-2">
             {sessions.map((session) => {
-              const info = infos.find(
-                (si) => si.session === session.name,
-              )
-              const spotsLeft = info
-                ? info.availableSpots
-                : maxAttendees - session.confirmedAttendees
-              const isFull = spotsLeft <= 0
-              const isBooked = info?.isUserBooked ?? false
+              const info = infoForSession(session, infos)
+              const spotsLeft = spotsLeftFor(session, info, maxAttendees)
+              const isFull = isSessionFull(session, info, maxAttendees)
+              const isBooked = isSessionBooked(info)
               const isSelected = selected.some(
                 (s) => s.name === session.name,
               )
@@ -207,22 +186,15 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
                   }`}
                 >
                   <div className="flex items-center gap-3">
-                    {multi && (
-                      <Checkbox
-                        checked={isSelected}
-                        disabled={isDisabled}
-                        className="pointer-events-none"
-                      />
-                    )}
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
                         <Calendar className="h-4 w-4 text-primary" />
                         <span className="font-medium text-foreground">
-                          {formatDate(session.date)}
+                          {formatSessionDate(session.date)}
                         </span>
                         <Clock className="ml-2 h-4 w-4 text-primary" />
                         <span className="text-foreground">
-                          {formatTime(session.date)}
+                          {formatSessionTime(session.date)}
                         </span>
                       </div>
                       <div className="mt-1 flex items-center gap-2">
@@ -242,7 +214,7 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
                         )}
                       </div>
                     </div>
-                    {isSelected && !multi && (
+                    {isSelected && (
                       <div className="text-sm font-semibold text-primary">
                         {moneyFormatter.format(standardPrice / 100n)}
                       </div>
@@ -256,27 +228,12 @@ export const SessionPicker: React.FC<SessionPickerProps> = ({
 
         {selected.length > 0 && (
           <div className="mt-4 space-y-3">
-            {multi && (
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">
-                  {selected.length} session{selected.length > 1 ? "s" : ""}{" "}
-                  selected
-                </span>
-                <span className="font-semibold text-primary">
-                  {moneyFormatter.format(
-                    (standardPrice * BigInt(selected.length)) / 100n,
-                  )}
-                </span>
-              </div>
-            )}
             <Button
               onClick={handleAddToCart}
               disabled={loading}
               className="relative w-full"
             >
-              {multi
-                ? `Add ${selected.length} Session${selected.length > 1 ? "s" : ""} to Cart`
-                : "Add to Cart"}
+              Add to Cart
               {loading && (
                 <Spinner className="absolute right-4 h-4 w-4 text-background" />
               )}

--- a/docs/superpowers/plans/2026-07-10-inline-session-selection.md
+++ b/docs/superpowers/plans/2026-07-10-inline-session-selection.md
@@ -1,0 +1,719 @@
+# Inline Session Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the class page's "Next Session" callout + "Select Sessions" modal with an inline, always-visible multi-session selection list inside the booking card, so customers pick sessions (up to 5) and book without opening a dialog.
+
+**Architecture:** The class page (`app/classes/[slug]/page.tsx`) is a server component that already fetches and sorts the upcoming sessions server-side. We pass that full `sessions` array (plus the existing `sessionInfos`) into `BookingCard`, which renders a new client component `InlineSessionSelector` in place of the removed callout / "Reserve Your Spot" button / "Book multiple sessions" modal trigger. All selection and availability logic is extracted into a pure, dependency-free module `lib/util/session-selection.ts` and unit-tested in the node/jsdom environment already configured on `master` (no new test dependencies). The rendered component's interaction is verified manually in the browser (the repo has no React Testing Library on `master`, and #3 must not depend on the unmerged gallery branch that introduced it). The booking action (`bookSessions`), cart wiring, login gate, toasts, and redirect to `/cart` are preserved unchanged — only lifted from the dialog into the inline component.
+
+**Tech Stack:** Next.js 14 (App Router) + TypeScript, shadcn/ui (`Checkbox`, `Badge`, `Button`, `Spinner`), Tailwind, `date-fns`/`Intl` for formatting, Vitest (already on `master`). Package manager npm. Prettier **no semicolons**.
+
+**Working directory:** the cool-mint worktree at `.claude/worktrees/inline-session-selection` (branch `feat/inline-session-selection`, based on `origin/master`). All commands run from the worktree root.
+
+## Global Constraints
+
+- **Unified single CTA (client decision):** the inline list is the *only* booking surface in the card. There is **no** separate "Reserve Your Spot" button and **no** "Next Session" callout — both are removed. The first *selectable* session is pre-selected by default; one CTA below the list books whatever is selected.
+- Preserve existing booking behaviour exactly: multi-select **up to 5**; per-session "spots left" / "Full" / "Already Booked" states; the same `bookSessions` server action; the same login gate, `cartContext.setCart`, toast messages, and `router.push("/cart")` redirect; the same empty state.
+- **Bounded height:** with many sessions the list scrolls within a fixed max height (`max-h-80 overflow-y-auto`) rather than lengthening the card.
+- **No data-fetching in the new component** — it consumes the server-fetched `sessions` prop. Do not call `upcomingSessions` client-side.
+- **Do not modify** `components/session-picker.tsx` or `components/related-class-card.tsx`. `SessionPicker` stays as-is because `related-class-card.tsx` still uses it in single mode. (Its now-caller-less `multi` branch is out of scope; leave it.)
+- **No new npm dependencies** and **no changes to `vitest.config.mts`**. Tests run under the existing config (jsdom env, `@vitejs/plugin-react`, `vite-tsconfig-paths`).
+- No proto/API contract changes. No changes to the "Choose Your Date" section (`components/classes.tsx`, `components/base/upcomingWorkshops.tsx`, `components/workshop.tsx`) — that is a separate existing booking path.
+- Code style: **no semicolons** (`.prettierrc`); `npm run lint` and `npx tsc --noEmit` must stay clean. Path alias `@/*` → repo root.
+
+## File Structure
+
+- `lib/util/session-selection.ts` (new) — pure selection/availability helpers. One responsibility: the rules for which sessions are bookable and how selection toggles within the cap. No React, no I/O.
+- `lib/util/session-selection.test.ts` (new) — unit tests for the above.
+- `components/inline-session-selector.tsx` (new) — `"use client"` component: renders the selectable list + summary + CTA, owns selection state and the add-to-cart flow.
+- `components/booking-card.tsx` (modify) — remove callout / reserve button / modal trigger / `SessionPicker` mount; render `InlineSessionSelector`; trim now-unused props and imports.
+- `app/classes/[slug]/page.tsx` (modify) — pass `sessions={masterClassSessions}` to `BookingCard`; stop passing `firstAvailableSession`, `masterClassName`, `displayName`.
+
+---
+
+## Task 1: Pure selection & availability helpers (TDD)
+
+**Files:**
+- Create: `lib/util/session-selection.ts`
+- Test: `lib/util/session-selection.test.ts`
+
+**Interfaces:**
+- Consumes: `Session` from `@/lib/fusion/masterClass/session.pb` (`{ name, uid, parent, date, product, confirmedAttendees, attendees }`); `SessionInfo` from `@/lib/fusion/masterClass/session.manager.pb` (`{ session, availableSpots, isUserBooked }`).
+- Produces (used by Task 2's component):
+  - `infoForSession(session: Session, infos: SessionInfo[]): SessionInfo | undefined`
+  - `spotsLeftFor(session: Session, info: SessionInfo | undefined, maxAttendees: number): number`
+  - `isSessionBooked(info: SessionInfo | undefined): boolean`
+  - `isSessionFull(session: Session, info: SessionInfo | undefined, maxAttendees: number): boolean`
+  - `firstSelectableSession(sessions: Session[], infos: SessionInfo[], maxAttendees: number): Session | undefined`
+  - `toggleSelection(selected: Session[], session: Session, maxSelections: number): Session[]`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/util/session-selection.test.ts`:
+```ts
+import { describe, it, expect } from "vitest"
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+import {
+  firstSelectableSession,
+  infoForSession,
+  isSessionBooked,
+  isSessionFull,
+  spotsLeftFor,
+  toggleSelection,
+} from "./session-selection"
+
+const session = (name: string, confirmedAttendees = 0): Session => ({
+  name,
+  uid: name,
+  parent: "masterClasses/x",
+  date: "2026-07-12T09:00:00Z",
+  product: "",
+  confirmedAttendees,
+  attendees: [],
+})
+
+const info = (
+  name: string,
+  availableSpots: number,
+  isUserBooked = false,
+): SessionInfo => ({ session: name, availableSpots, isUserBooked })
+
+describe("spotsLeftFor", () => {
+  it("uses SessionInfo.availableSpots when the info is present", () => {
+    expect(spotsLeftFor(session("s1", 5), info("s1", 3), 6)).toBe(3)
+  })
+
+  it("falls back to maxAttendees - confirmedAttendees when no info", () => {
+    expect(spotsLeftFor(session("s1", 4), undefined, 6)).toBe(2)
+  })
+})
+
+describe("isSessionBooked", () => {
+  it("is true when the info marks the user booked", () => {
+    expect(isSessionBooked(info("s1", 3, true))).toBe(true)
+  })
+
+  it("is false when info is absent or not booked", () => {
+    expect(isSessionBooked(info("s1", 3, false))).toBe(false)
+    expect(isSessionBooked(undefined)).toBe(false)
+  })
+})
+
+describe("isSessionFull", () => {
+  it("is true when zero spots remain", () => {
+    expect(isSessionFull(session("s1"), info("s1", 0), 6)).toBe(true)
+  })
+
+  it("is false when spots remain", () => {
+    expect(isSessionFull(session("s1"), info("s1", 1), 6)).toBe(false)
+  })
+})
+
+describe("infoForSession", () => {
+  it("matches the info whose session equals the session name", () => {
+    const infos = [info("s1", 1), info("s2", 2)]
+    expect(infoForSession(session("s2"), infos)?.availableSpots).toBe(2)
+  })
+
+  it("returns undefined when no info matches", () => {
+    expect(infoForSession(session("s3"), [info("s1", 1)])).toBeUndefined()
+  })
+})
+
+describe("firstSelectableSession", () => {
+  it("returns the first session with spots that is not booked", () => {
+    const sessions = [session("full"), session("open"), session("open2")]
+    const infos = [info("full", 0), info("open", 2), info("open2", 3)]
+    expect(firstSelectableSession(sessions, infos, 6)?.name).toBe("open")
+  })
+
+  it("skips sessions the user has already booked", () => {
+    const sessions = [session("booked"), session("open")]
+    const infos = [info("booked", 2, true), info("open", 2)]
+    expect(firstSelectableSession(sessions, infos, 6)?.name).toBe("open")
+  })
+
+  it("returns undefined when nothing is selectable", () => {
+    const sessions = [session("full")]
+    const infos = [info("full", 0)]
+    expect(firstSelectableSession(sessions, infos, 6)).toBeUndefined()
+  })
+})
+
+describe("toggleSelection", () => {
+  const s1 = session("s1")
+  const s2 = session("s2")
+
+  it("adds a session that is not selected", () => {
+    expect(toggleSelection([], s1, 5).map((s) => s.name)).toEqual(["s1"])
+  })
+
+  it("removes a session that is already selected", () => {
+    expect(toggleSelection([s1, s2], s1, 5).map((s) => s.name)).toEqual(["s2"])
+  })
+
+  it("does not add beyond maxSelections", () => {
+    const five = [1, 2, 3, 4, 5].map((n) => session("s" + n))
+    const result = toggleSelection(five, session("s6"), 5)
+    expect(result).toHaveLength(5)
+    expect(result.map((s) => s.name)).not.toContain("s6")
+  })
+
+  it("still allows removing when at the cap", () => {
+    const five = [1, 2, 3, 4, 5].map((n) => session("s" + n))
+    const result = toggleSelection(five, five[0], 5)
+    expect(result.map((s) => s.name)).toEqual(["s2", "s3", "s4", "s5"])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run (from the worktree root): `npm test`
+Expected: FAIL — cannot resolve `./session-selection` (module does not exist yet).
+
+- [ ] **Step 3: Create the module**
+
+Create `lib/util/session-selection.ts`:
+```ts
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+
+// Per-session availability comes from the parallel SessionInfo array (matched by
+// `info.session === session.name`); capacity is the master class's maxAttendees.
+export function infoForSession(
+  session: Session,
+  infos: SessionInfo[],
+): SessionInfo | undefined {
+  return infos.find((si) => si.session === session.name)
+}
+
+export function spotsLeftFor(
+  session: Session,
+  info: SessionInfo | undefined,
+  maxAttendees: number,
+): number {
+  return info ? info.availableSpots : maxAttendees - session.confirmedAttendees
+}
+
+export function isSessionBooked(info: SessionInfo | undefined): boolean {
+  return info?.isUserBooked ?? false
+}
+
+export function isSessionFull(
+  session: Session,
+  info: SessionInfo | undefined,
+  maxAttendees: number,
+): boolean {
+  return spotsLeftFor(session, info, maxAttendees) <= 0
+}
+
+// The session to pre-select by default: the first one that is neither full nor
+// already booked by the user.
+export function firstSelectableSession(
+  sessions: Session[],
+  infos: SessionInfo[],
+  maxAttendees: number,
+): Session | undefined {
+  return sessions.find((s) => {
+    const info = infoForSession(s, infos)
+    return !isSessionFull(s, info, maxAttendees) && !isSessionBooked(info)
+  })
+}
+
+// Toggle a session in/out of the selection, enforcing the max-selection cap.
+// Removing an already-selected session always succeeds, even at the cap.
+export function toggleSelection(
+  selected: Session[],
+  session: Session,
+  maxSelections: number,
+): Session[] {
+  if (selected.some((s) => s.name === session.name)) {
+    return selected.filter((s) => s.name !== session.name)
+  }
+  if (selected.length >= maxSelections) {
+    return selected
+  }
+  return [...selected, session]
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run (from the worktree root): `npm test`
+Expected: PASS — `session-selection` suite green; `format-duration` suite (pre-existing) still green.
+
+- [ ] **Step 5: Lint & type-check the new files**
+
+Run (from the worktree root):
+```bash
+npm run lint
+npx tsc --noEmit
+```
+Expected: clean. If `tsc` reports pre-existing errors unrelated to `lib/util/session-selection.*`, note them in the report rather than fixing them (out of scope).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/util/session-selection.ts lib/util/session-selection.test.ts
+git commit -m "feat: add pure session selection/availability helpers"
+```
+
+---
+
+## Task 2: Inline selector component + wire it into the booking card
+
+**Files:**
+- Create: `components/inline-session-selector.tsx`
+- Modify: `components/booking-card.tsx`
+- Modify: `app/classes/[slug]/page.tsx`
+
+**Interfaces:**
+- Consumes: the Task 1 helpers; `bookSessions` from `@/app/classes/actions`; `useCart`, `useUser`; `Session`, `SessionInfo`; `moneyFormatter`; `parseError`; shadcn `Badge`/`Button`/`Checkbox`/`Spinner`.
+- Produces: `InlineSessionSelector` (default export not required; named export). `BookingCard` renders it. `page.tsx` feeds `BookingCard` the `sessions` array.
+
+- [ ] **Step 1: Create the `InlineSessionSelector` component**
+
+Create `components/inline-session-selector.tsx`:
+```tsx
+"use client"
+
+import { bookSessions } from "@/app/classes/actions"
+import { useCart } from "@/contexts/cart"
+import { useUser } from "@/contexts/user"
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+import { parseError } from "@/lib/util/error"
+import { moneyFormatter } from "@/lib/util/money-formatter"
+import {
+  firstSelectableSession,
+  infoForSession,
+  isSessionBooked,
+  isSessionFull,
+  spotsLeftFor,
+  toggleSelection,
+} from "@/lib/util/session-selection"
+import { Calendar, Clock, Users } from "lucide-react"
+import { usePathname, useRouter } from "next/navigation"
+import React from "react"
+import { toast } from "sonner"
+import { Badge } from "./ui/badge"
+import { Button } from "./ui/button"
+import { Checkbox } from "./ui/checkbox"
+import { Spinner } from "./ui/spinner"
+
+interface InlineSessionSelectorProps {
+  maxAttendees: number
+  standardPrice: bigint
+  sessions: Session[]
+  sessionInfos?: SessionInfo[]
+  maxSelections?: number
+}
+
+const formatDate = (dateStr: string) =>
+  new Date(dateStr).toLocaleDateString("en-ZA", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+  })
+
+const formatTime = (dateStr: string) =>
+  new Date(dateStr).toLocaleTimeString("en-ZA", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+
+export const InlineSessionSelector: React.FC<InlineSessionSelectorProps> = ({
+  maxAttendees,
+  standardPrice,
+  sessions,
+  sessionInfos,
+  maxSelections = 5,
+}) => {
+  const router = useRouter()
+  const user = useUser()
+  const cartContext = useCart()
+  const pathname = usePathname()
+  const infos = sessionInfos ?? []
+  const [selected, setSelected] = React.useState<Session[]>(() => {
+    const first = firstSelectableSession(sessions, infos, maxAttendees)
+    return first ? [first] : []
+  })
+  const [loading, setLoading] = React.useState(false)
+
+  const toggleSession = (session: Session) => {
+    setSelected((prev) => toggleSelection(prev, session, maxSelections))
+  }
+
+  const handleAddToCart = async () => {
+    if (!user) {
+      const loginUrl = new URL("/login", window.location.origin)
+      if (pathname !== "/") {
+        loginUrl.searchParams.set("redirect", pathname.slice(1))
+      }
+      toast("Please login to book your spot", {
+        action: {
+          label: "Login",
+          onClick: () => router.push(loginUrl.toString()),
+        },
+      })
+      return
+    }
+
+    if (selected.length === 0) return
+
+    try {
+      setLoading(true)
+      const response = await bookSessions({
+        items: selected.map((s) => ({ session: s.name, quantity: 1 })),
+      })
+
+      if (response.cart) {
+        cartContext.setCart(response.cart)
+      }
+
+      setLoading(false)
+
+      if (response.errors.length > 0 && response.booked.length > 0) {
+        toast.warning(
+          `Added ${response.booked.length} session${response.booked.length > 1 ? "s" : ""} to cart. ${response.errors.length} failed: ${response.errors.map((e) => e.reason).join(", ")}`,
+        )
+      } else if (response.errors.length > 0) {
+        toast.error(response.errors.map((e) => e.reason).join(", "))
+        return
+      } else {
+        toast.success(
+          response.booked.length === 1
+            ? "Added to cart"
+            : `Added ${response.booked.length} sessions to cart`,
+        )
+      }
+      router.push("/cart")
+    } catch (e: unknown) {
+      setLoading(false)
+      toast.error("Failed to add to cart: " + parseError(e))
+    }
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="mb-3 flex items-center justify-between">
+        <p className="font-helvetica font-semibold text-foreground">
+          Select sessions
+        </p>
+        <span className="text-xs text-muted-foreground">
+          up to {maxSelections}
+        </span>
+      </div>
+
+      {sessions.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No upcoming sessions available
+        </p>
+      ) : (
+        <div className="max-h-80 space-y-2 overflow-y-auto pr-1">
+          {sessions.map((session) => {
+            const info = infoForSession(session, infos)
+            const spotsLeft = spotsLeftFor(session, info, maxAttendees)
+            const isFull = isSessionFull(session, info, maxAttendees)
+            const isBooked = isSessionBooked(info)
+            const isSelected = selected.some((s) => s.name === session.name)
+            const isDisabled = isFull || isBooked
+
+            return (
+              <button
+                key={session.name}
+                type="button"
+                disabled={isDisabled}
+                onClick={() => toggleSession(session)}
+                className={`w-full rounded-lg border p-3 text-left transition-colors ${
+                  isSelected
+                    ? "border-primary bg-primary/10"
+                    : isDisabled
+                      ? "cursor-not-allowed border-muted/20 opacity-50"
+                      : "border-muted/20 hover:border-primary/50"
+                }`}
+              >
+                <div className="flex items-center gap-3">
+                  <Checkbox
+                    checked={isSelected}
+                    disabled={isDisabled}
+                    className="pointer-events-none"
+                  />
+                  <div className="flex-1">
+                    <div className="flex items-center gap-2">
+                      <Calendar className="h-4 w-4 text-primary" />
+                      <span className="font-medium text-foreground">
+                        {formatDate(session.date)}
+                      </span>
+                      <Clock className="ml-2 h-4 w-4 text-primary" />
+                      <span className="text-foreground">
+                        {formatTime(session.date)}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <Users className="h-3 w-3 text-muted-foreground" />
+                      {isBooked ? (
+                        <Badge variant="secondary" className="text-xs">
+                          Already Booked
+                        </Badge>
+                      ) : isFull ? (
+                        <Badge variant="destructive" className="text-xs">
+                          Full
+                        </Badge>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">
+                          {spotsLeft} spots left
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {selected.length > 0 && (
+        <div className="mt-4 space-y-3">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              {selected.length} session{selected.length > 1 ? "s" : ""} selected
+            </span>
+            <span className="font-semibold text-primary">
+              {moneyFormatter.format(
+                (standardPrice * BigInt(selected.length)) / 100n,
+              )}
+            </span>
+          </div>
+          <Button
+            onClick={handleAddToCart}
+            disabled={loading}
+            className="relative w-full"
+          >
+            {selected.length > 1
+              ? `Add ${selected.length} Sessions to Cart`
+              : "Add to Cart"}
+            {loading && (
+              <Spinner className="absolute right-4 h-4 w-4 text-background" />
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Rewrite `booking-card.tsx` to use the inline selector**
+
+Replace the entire contents of `components/booking-card.tsx` with:
+```tsx
+"use client"
+
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+import { formatDuration } from "@/lib/util/format-duration"
+import { moneyFormatter } from "@/lib/util/money-formatter"
+import { Clock, MapPin, SignalHigh, Users } from "lucide-react"
+import React from "react"
+import { InlineSessionSelector } from "./inline-session-selector"
+
+interface BookingCardProps {
+  standardPrice: bigint
+  difficulty: string
+  duration: number
+  maxAttendees: number
+  spotsFilled: number
+  sessions: Session[]
+  sessionInfos?: SessionInfo[]
+}
+
+export const BookingCard: React.FC<BookingCardProps> = ({
+  standardPrice,
+  difficulty,
+  duration,
+  maxAttendees,
+  spotsFilled,
+  sessions,
+  sessionInfos,
+}) => {
+  const spotsRemaining = maxAttendees - spotsFilled
+  const fillPercentage = (spotsFilled / maxAttendees) * 100
+
+  return (
+    <div
+      className={
+        "rounded-lg border border-primary/10 bg-[#262626] px-6 py-6 font-helvetica"
+      }
+    >
+      {/* Price */}
+      <div className="mb-6">
+        <span className="font-helvetica text-3xl font-bold text-primary">
+          {moneyFormatter.format(standardPrice / 100n)}
+        </span>
+        <p className="text-sm text-muted-foreground">per person</p>
+      </div>
+
+      {/* Class Details */}
+      <div className="space-y-4">
+        {/* Difficulty */}
+        <div className="flex items-start gap-3">
+          <SignalHigh className="mt-0.5 h-5 w-5 text-primary" />
+          <div>
+            <p className="text-xs text-muted-foreground">Difficulty</p>
+            <p className="font-helvetica font-medium normal-case text-foreground">
+              {difficulty}
+            </p>
+          </div>
+        </div>
+
+        {/* Time */}
+        <div className="flex items-start gap-3">
+          <Clock className="mt-0.5 h-5 w-5 text-primary" />
+          <div>
+            <p className="text-xs text-muted-foreground">Time</p>
+            <p className="font-helvetica font-medium text-foreground">
+              {formatDuration(duration)}
+            </p>
+          </div>
+        </div>
+
+        {/* Location */}
+        <div className="flex items-start gap-3">
+          <MapPin className="mt-0.5 h-5 w-5 text-primary" />
+          <div>
+            <p className="text-xs text-muted-foreground">Location</p>
+            <p className="font-helvetica font-medium text-foreground">
+              10 Naaf St, Strydompark, Randburg, 2169
+            </p>
+          </div>
+        </div>
+
+        {/* Availability */}
+        <div className="flex items-start gap-3">
+          <Users className="mt-0.5 h-5 w-5 text-primary" />
+          <div className="flex-1">
+            <p className="text-xs text-muted-foreground">Availability</p>
+            <p className="font-helvetica font-medium text-foreground">
+              {spotsFilled} / {maxAttendees} spots filled
+            </p>
+            {/* Progress Bar */}
+            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{ width: `${fillPercentage}%` }}
+              />
+            </div>
+            <p className="mt-1 text-sm text-primary">
+              {spotsRemaining} spots remaining
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Inline session selection + booking CTA */}
+      <InlineSessionSelector
+        maxAttendees={maxAttendees}
+        standardPrice={standardPrice}
+        sessions={sessions}
+        sessionInfos={sessionInfos}
+        maxSelections={5}
+      />
+
+      {/* Cancellation Policy */}
+      <p className="mt-4 text-center text-xs text-white/80">
+        Free cancellation up to 48 hours before class
+      </p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Update the class page to pass `sessions`**
+
+In `app/classes/[slug]/page.tsx`, the `<BookingCard .../>` element is currently (around lines 132–142):
+```tsx
+              <BookingCard
+                masterClassName={masterClass.name}
+                displayName={masterClass.displayName}
+                standardPrice={masterClass.standardPrice}
+                difficulty={masterClass.difficulty}
+                duration={masterClass.duration}
+                maxAttendees={totalSpots}
+                spotsFilled={spotsFilled}
+                firstAvailableSession={firstAvailableSession}
+                sessionInfos={sessionInfos}
+              />
+```
+Replace it with (drop `masterClassName`, `displayName`, `firstAvailableSession`; add `sessions`):
+```tsx
+              <BookingCard
+                standardPrice={masterClass.standardPrice}
+                difficulty={masterClass.difficulty}
+                duration={masterClass.duration}
+                maxAttendees={totalSpots}
+                spotsFilled={spotsFilled}
+                sessions={masterClassSessions}
+                sessionInfos={sessionInfos}
+              />
+```
+Leave the rest of `page.tsx` unchanged: `firstAvailableSession` is still computed locally to derive `spotsFilled` (line ~49–53), so keep that block. Do **not** remove the `firstAvailableSession` local variable.
+
+- [ ] **Step 4: Verify lint & types**
+
+Run (from the worktree root):
+```bash
+npm run lint
+npx tsc --noEmit
+```
+Expected: clean. Common gotchas this must catch:
+- No unused imports/vars in `booking-card.tsx` (removed: `bookSessions`, `useCart`, `useUser`, `usePathname`, `useRouter`, `toast`, `parseError`, `format` from date-fns, `Calendar`, `Spinner`, `SessionPicker`, and the removed props).
+- No unused `firstAvailableSession`-related props in `page.tsx` (the JSX no longer passes them, but the local `const firstAvailableSession` is still used for `spotsFilled`).
+If `tsc` reports pre-existing errors unrelated to the three changed files, note them in the report (out of scope).
+
+- [ ] **Step 5: Run the full test suite**
+
+Run (from the worktree root): `npm test`
+Expected: PASS — `session-selection` and `format-duration` suites green. (No test renders `InlineSessionSelector`; its interaction is covered by the manual verification gate below, since React Testing Library is not available on `master`.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/inline-session-selector.tsx components/booking-card.tsx "app/classes/[slug]/page.tsx"
+git commit -m "feat: inline multi-session selection on the class page"
+```
+
+---
+
+## Manual Verification Gate (browser — required before merge)
+
+The rendered component is not unit-tested (no RTL on `master`). Before this branch merges, verify in the browser (`npm run dev`, open a class page):
+
+1. **List renders inline** — no "Next Session" callout, no "Reserve Your Spot" button, no "Book multiple sessions" link, no dialog. The selectable list sits inside the booking card under the availability block.
+2. **Default selection** — the first session with spots (not full, not already booked) is pre-checked, the summary reads "1 session selected", and the total equals one seat's price.
+3. **Multi-select + cap** — checking more sessions updates the count and total; the 6th selection is refused (cap 5). Unchecking removes it.
+4. **Per-session states** — a full session shows the "Full" badge and is not selectable; "N spots left" shows for available ones.
+5. **Booking flow** — logged out → login toast with redirect; logged in → "Add to Cart" books the selected sessions, cart updates, redirect to `/cart`. Error/partial-error toasts behave as before.
+6. **Empty state** — a class with no upcoming sessions shows "No upcoming sessions available" and no CTA.
+7. **Bounded height** — a class with many sessions scrolls the list within the card instead of lengthening the page.
+8. **Related-class card unaffected** — the "Book" button on related-class cards still opens the `SessionPicker` dialog (single mode) and books correctly.
+
+---
+
+## Self-Review
+
+**1. Spec coverage (#3):**
+- Replace "Next Session" callout + "Select Sessions" modal with an inline selectable list → Task 2 removes both and renders `InlineSessionSelector` inline. ✅
+- Multi-select up to 5 → `toggleSelection` cap (Task 1), tested; `maxSelections={5}` wired (Task 2). ✅
+- Per-session "spots left" / Full / Already Booked → `spotsLeftFor`/`isSessionFull`/`isSessionBooked` (Task 1) drive the badges (Task 2). ✅
+- Same `bookSessions` action, cart, login gate, toasts, redirect → lifted verbatim into `InlineSessionSelector.handleAddToCart`. ✅
+- Empty state → "No upcoming sessions available" (Task 2). ✅
+- Many sessions scroll within bounded height → `max-h-80 overflow-y-auto` (Task 2, Global Constraints). ✅
+- Remove the now-unused modal trigger; keep `SessionPicker` (still used by `related-class-card.tsx`) → Global Constraints; `session-picker.tsx` untouched. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete file content or an exact before/after JSX replacement. The lint step lists the concrete unused symbols to remove — that is a verification checklist, not a placeholder. ✅
+
+**3. Type consistency:** `InlineSessionSelectorProps` (`maxAttendees`, `standardPrice: bigint`, `sessions: Session[]`, `sessionInfos?: SessionInfo[]`, `maxSelections?`) matches the `<InlineSessionSelector>` call in `booking-card.tsx`. `BookingCardProps` matches the `<BookingCard>` call in `page.tsx` (both drop `masterClassName`/`displayName`/`firstAvailableSession`, both add `sessions`). Helper signatures in Task 1's "Produces" block match their imports and call sites in Task 2. `standardPrice` stays `bigint` end-to-end; totals use `/ 100n` as before. ✅

--- a/docs/superpowers/plans/2026-07-13-session-picker-followups.md
+++ b/docs/superpowers/plans/2026-07-13-session-picker-followups.md
@@ -1,0 +1,90 @@
+# Plan: session-picker fast-follows (PR #118 out-of-scope items 2 & 3)
+
+Two independent fast-follow cleanups to the inline-session-selection work in PR
+#118 (`feat/inline-session-selection`). Both live in `cool-mint`. This branch
+(`fix/inline-session-followups`) is stacked on the PR branch.
+
+## Context
+
+PR #118 replaced the class page's "Next Session" callout + "Select Sessions"
+modal with an inline multi-session selector (`components/inline-session-selector.tsx`)
+built on pure helpers in `lib/util/session-selection.ts`. Two loose ends were
+noted as out of scope:
+
+- **Item 2:** `components/session-picker.tsx` still carries a `multi` mode that
+  no caller uses anymore, plus its own copies of availability + date/time logic
+  that duplicate the shared helpers.
+- **Item 3:** On a class with no upcoming sessions the "Choose Your Date" section
+  renders an empty tab bar instead of hiding.
+
+## Global Constraints
+
+- Package manager is **npm**. `npm test` (vitest), `npm run lint`, `npx tsc --noEmit`
+  must all stay green. Baseline before this branch: 24/24 tests pass.
+- Prettier style: **no semicolons**; `prettier-plugin-tailwindcss` sorts classes.
+  Match surrounding code exactly.
+- **No behavior change** for the one live caller of `SessionPicker`
+  (`components/related-class-card.tsx`), which uses it in single-select dialog
+  mode. Single-select semantics must be preserved exactly: clicking the selected
+  row deselects it; clicking a different row *replaces* the selection.
+- Do not touch `components/inline-session-selector.tsx` or
+  `lib/util/session-selection.ts` (already shipped in #118) except to consume
+  existing exports.
+- Session date/time in customer-facing session lists must render in **SAST
+  (Africa/Johannesburg)** — use the shared `formatSessionDate` / `formatSessionTime`
+  helpers, never a runtime-local `new Date().toLocaleString`.
+
+## Task 1: Collapse SessionPicker onto shared helpers, remove dead multi mode
+
+**File:** `components/session-picker.tsx` (only). Its sole caller is
+`components/related-class-card.tsx`, which never passes `multi` (defaults to
+`false`), so every `multi`-conditional branch is dead code.
+
+**Remove the dead `multi` mode:**
+- Drop the `multi` and `maxSelections` props from `SessionPickerProps` and the
+  component signature.
+- Remove the `Checkbox` import and its render block (the presentational checkbox
+  only ever appeared in multi mode).
+- Simplify `toggleSession` to single-select only: selected row → deselect;
+  other row → replace selection with `[session]`. (Do **not** use the shared
+  `toggleSelection` helper — its cap-based append semantics differ from
+  single-select replace.)
+- Remove the multi-only dialog title ("Select Sessions"), the "select up to N"
+  subtitle suffix, the multi selection-count/subtotal summary row, and the
+  multi "Add N Sessions to Cart" button label. Title is always "Choose a Date";
+  button label is always "Add to Cart".
+
+**Collapse duplicated logic onto `lib/util/session-selection.ts`:**
+- Replace the inline `spotsLeft` / `isFull` / `isBooked` computations with
+  `infoForSession`, `spotsLeftFor`, `isSessionFull`, `isSessionBooked`.
+- Delete the component-local `formatDate` / `formatTime` (which lack a `timeZone`
+  and are a latent SAST/hydration bug) and use the shared `formatSessionDate` /
+  `formatSessionTime`.
+
+**Preserve unchanged:** the fetch-on-open effect, the `sessionInfos` prop and
+fetched-infos fallback (`infos = sessionInfos ?? fetchedInfos`), the login-gate +
+toast + `bookSessions` → cart → `/cart` flow, and the per-row price shown for the
+selected session in single mode.
+
+**Verification:** `npx tsc --noEmit` and `npm run lint` clean. There is no unit
+test for this component; confirm `related-class-card.tsx` still type-checks and
+its `<SessionPicker>` usage compiles unchanged.
+
+## Task 2: Hide the "Choose Your Date" section when there are no upcoming sessions
+
+**File:** `app/classes/[slug]/page.tsx` (only).
+
+The page already server-fetches sessions into `masterClassSessions` (sorted). The
+"Choose Your Date" block — the `<hr>` divider, the `<div id="choose-date">` heading,
+and the `<Suspense><UpcomingClasses …/></Suspense>` wrapper (roughly lines
+179–190) — currently renders unconditionally, so an empty class shows a heading
+over an empty tab bar.
+
+**Change:** wrap that whole block in `{masterClassSessions.length > 0 && ( … )}`
+so it renders nothing when there are no upcoming sessions. Hide the section
+entirely — do **not** add an empty-state message here; the booking card already
+shows its own "No upcoming sessions available" state.
+
+**Verification:** `npx tsc --noEmit` and `npm run lint` clean. Confirm the JSX
+still balances and the divider/spacing for the following "Related Classes"
+section is unaffected when sessions exist.

--- a/lib/util/session-selection.test.ts
+++ b/lib/util/session-selection.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest"
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+import {
+  firstSelectableSession,
+  infoForSession,
+  isSessionBooked,
+  isSessionFull,
+  spotsLeftFor,
+  toggleSelection,
+} from "./session-selection"
+
+const session = (name: string, confirmedAttendees = 0): Session => ({
+  name,
+  uid: name,
+  parent: "masterClasses/x",
+  date: "2026-07-12T09:00:00Z",
+  product: "",
+  confirmedAttendees,
+  attendees: [],
+})
+
+const info = (
+  name: string,
+  availableSpots: number,
+  isUserBooked = false,
+): SessionInfo => ({ session: name, availableSpots, isUserBooked })
+
+describe("spotsLeftFor", () => {
+  it("uses SessionInfo.availableSpots when the info is present", () => {
+    expect(spotsLeftFor(session("s1", 5), info("s1", 3), 6)).toBe(3)
+  })
+
+  it("falls back to maxAttendees - confirmedAttendees when no info", () => {
+    expect(spotsLeftFor(session("s1", 4), undefined, 6)).toBe(2)
+  })
+})
+
+describe("isSessionBooked", () => {
+  it("is true when the info marks the user booked", () => {
+    expect(isSessionBooked(info("s1", 3, true))).toBe(true)
+  })
+
+  it("is false when info is absent or not booked", () => {
+    expect(isSessionBooked(info("s1", 3, false))).toBe(false)
+    expect(isSessionBooked(undefined)).toBe(false)
+  })
+})
+
+describe("isSessionFull", () => {
+  it("is true when zero spots remain", () => {
+    expect(isSessionFull(session("s1"), info("s1", 0), 6)).toBe(true)
+  })
+
+  it("is false when spots remain", () => {
+    expect(isSessionFull(session("s1"), info("s1", 1), 6)).toBe(false)
+  })
+})
+
+describe("infoForSession", () => {
+  it("matches the info whose session equals the session name", () => {
+    const infos = [info("s1", 1), info("s2", 2)]
+    expect(infoForSession(session("s2"), infos)?.availableSpots).toBe(2)
+  })
+
+  it("returns undefined when no info matches", () => {
+    expect(infoForSession(session("s3"), [info("s1", 1)])).toBeUndefined()
+  })
+})
+
+describe("firstSelectableSession", () => {
+  it("returns the first session with spots that is not booked", () => {
+    const sessions = [session("full"), session("open"), session("open2")]
+    const infos = [info("full", 0), info("open", 2), info("open2", 3)]
+    expect(firstSelectableSession(sessions, infos, 6)?.name).toBe("open")
+  })
+
+  it("skips sessions the user has already booked", () => {
+    const sessions = [session("booked"), session("open")]
+    const infos = [info("booked", 2, true), info("open", 2)]
+    expect(firstSelectableSession(sessions, infos, 6)?.name).toBe("open")
+  })
+
+  it("returns undefined when nothing is selectable", () => {
+    const sessions = [session("full")]
+    const infos = [info("full", 0)]
+    expect(firstSelectableSession(sessions, infos, 6)).toBeUndefined()
+  })
+})
+
+describe("toggleSelection", () => {
+  const s1 = session("s1")
+  const s2 = session("s2")
+
+  it("adds a session that is not selected", () => {
+    expect(toggleSelection([], s1, 5).map((s) => s.name)).toEqual(["s1"])
+  })
+
+  it("removes a session that is already selected", () => {
+    expect(toggleSelection([s1, s2], s1, 5).map((s) => s.name)).toEqual(["s2"])
+  })
+
+  it("does not add beyond maxSelections", () => {
+    const five = [1, 2, 3, 4, 5].map((n) => session("s" + n))
+    const result = toggleSelection(five, session("s6"), 5)
+    expect(result).toHaveLength(5)
+    expect(result.map((s) => s.name)).not.toContain("s6")
+  })
+
+  it("still allows removing when at the cap", () => {
+    const five = [1, 2, 3, 4, 5].map((n) => session("s" + n))
+    const result = toggleSelection(five, five[0], 5)
+    expect(result.map((s) => s.name)).toEqual(["s2", "s3", "s4", "s5"])
+  })
+})

--- a/lib/util/session-selection.test.ts
+++ b/lib/util/session-selection.test.ts
@@ -3,6 +3,8 @@ import { Session } from "@/lib/fusion/masterClass/session.pb"
 import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
 import {
   firstSelectableSession,
+  formatSessionDate,
+  formatSessionTime,
   infoForSession,
   isSessionBooked,
   isSessionFull,
@@ -111,5 +113,26 @@ describe("toggleSelection", () => {
     const five = [1, 2, 3, 4, 5].map((n) => session("s" + n))
     const result = toggleSelection(five, five[0], 5)
     expect(result.map((s) => s.name)).toEqual(["s2", "s3", "s4", "s5"])
+  })
+})
+
+describe("formatSessionTime", () => {
+  it("applies the Africa/Johannesburg (UTC+2) offset, not the runtime's local zone", () => {
+    // 07:00 UTC is 09:00 in SAST (UTC+2).
+    const result = formatSessionTime("2026-07-12T07:00:00Z")
+    expect(result).toContain("09")
+    expect(result).not.toContain("07")
+  })
+
+  it("rolls the time across midnight in SAST near a date boundary", () => {
+    // 23:30 UTC is 01:30 the following day in SAST.
+    expect(formatSessionTime("2026-07-12T23:30:00Z")).toContain("01")
+  })
+})
+
+describe("formatSessionDate", () => {
+  it("rolls the date forward when SAST has already crossed midnight", () => {
+    // 23:30 UTC on the 12th is 01:30 on the 13th in SAST.
+    expect(formatSessionDate("2026-07-12T23:30:00Z")).toContain("13")
   })
 })

--- a/lib/util/session-selection.ts
+++ b/lib/util/session-selection.ts
@@ -1,0 +1,60 @@
+import { Session } from "@/lib/fusion/masterClass/session.pb"
+import { SessionInfo } from "@/lib/fusion/masterClass/session.manager.pb"
+
+// Per-session availability comes from the parallel SessionInfo array (matched by
+// `info.session === session.name`); capacity is the master class's maxAttendees.
+export function infoForSession(
+  session: Session,
+  infos: SessionInfo[],
+): SessionInfo | undefined {
+  return infos.find((si) => si.session === session.name)
+}
+
+export function spotsLeftFor(
+  session: Session,
+  info: SessionInfo | undefined,
+  maxAttendees: number,
+): number {
+  return info ? info.availableSpots : maxAttendees - session.confirmedAttendees
+}
+
+export function isSessionBooked(info: SessionInfo | undefined): boolean {
+  return info?.isUserBooked ?? false
+}
+
+export function isSessionFull(
+  session: Session,
+  info: SessionInfo | undefined,
+  maxAttendees: number,
+): boolean {
+  return spotsLeftFor(session, info, maxAttendees) <= 0
+}
+
+// The session to pre-select by default: the first one that is neither full nor
+// already booked by the user.
+export function firstSelectableSession(
+  sessions: Session[],
+  infos: SessionInfo[],
+  maxAttendees: number,
+): Session | undefined {
+  return sessions.find((s) => {
+    const info = infoForSession(s, infos)
+    return !isSessionFull(s, info, maxAttendees) && !isSessionBooked(info)
+  })
+}
+
+// Toggle a session in/out of the selection, enforcing the max-selection cap.
+// Removing an already-selected session always succeeds, even at the cap.
+export function toggleSelection(
+  selected: Session[],
+  session: Session,
+  maxSelections: number,
+): Session[] {
+  if (selected.some((s) => s.name === session.name)) {
+    return selected.filter((s) => s.name !== session.name)
+  }
+  if (selected.length >= maxSelections) {
+    return selected
+  }
+  return [...selected, session]
+}

--- a/lib/util/session-selection.ts
+++ b/lib/util/session-selection.ts
@@ -58,3 +58,27 @@ export function toggleSelection(
   }
   return [...selected, session]
 }
+
+// Session date/time formatting is pinned to Africa/Johannesburg (SAST, UTC+2)
+// rather than left to the runtime's local timezone. This deployment is
+// South-Africa-only, and these components are server-rendered first (UTC on
+// Cloud Run) then hydrated client-side (SAST in the browser) — without an
+// explicit timeZone the two renders disagree and React throws a hydration
+// mismatch, or worse, briefly shows a time that's 2 hours off on a booking
+// decision.
+export function formatSessionDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-ZA", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    timeZone: "Africa/Johannesburg",
+  })
+}
+
+export function formatSessionTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleTimeString("en-ZA", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: "Africa/Johannesburg",
+  })
+}


### PR DESCRIPTION
## What & why

Client request (June change requests, item 3): *"Next session section — I think it can just be replaced."*

Replaces the class page's **"Next Session" callout + "Select Sessions" modal** with an **inline, always-visible multi-session selection list** inside the booking card. Customers pick sessions (up to 5) and book without opening a dialog.

Agreed design: a **unified single CTA** — the inline list is the only booking surface (no separate "Reserve Your Spot" button, no callout, no dialog). The first *selectable* session (not full, not already booked) is pre-selected; one CTA books the selection.

## Changes

- **`lib/util/session-selection.ts`** (new) — pure, dependency-free selection/availability helpers (`spotsLeftFor`, `isSessionFull`, `firstSelectableSession`, `toggleSelection`, …) plus SAST-pinned `formatSessionDate`/`formatSessionTime`. Unit-tested (18 tests).
- **`components/inline-session-selector.tsx`** (new) — thin client component over those helpers: selectable list, pre-selection, up-to-5 cap, per-session "spots left"/"Full"/"Already Booked", bounded-height scroll, empty state, and the `bookSessions` → cart → `/cart` flow (login gate + toasts preserved).
- **`components/booking-card.tsx`** — rewritten: callout, "Reserve Your Spot", modal trigger, and `SessionPicker` mount removed; renders the inline selector.
- **`app/classes/[slug]/page.tsx`** — passes the already-server-fetched `sessions` to the card (no extra client fetch).

`components/related-class-card.tsx` is intentionally **untouched** — it remains the only caller of `SessionPicker`, in single (dialog) mode. (`components/session-picker.tsx` itself *is* updated — see **Fast-follows folded in** below.)

### Fixes found during local browser testing (also in this PR)

- **`fix: avoid nested-button hydration error`** — each session row is a `<button>`; the Radix `<Checkbox>` inside also renders a `<button>` (invalid HTML). Harmless in the old dialog (client-only) but threw a hydration error once the list became server-rendered inline. Replaced the decorative checkbox with a presentational indicator + `aria-pressed` on the row toggle.
- **`fix: guard class-page crash when a class has no upcoming sessions`** — pre-existing bug in `components/base/upcomingWorkshops.tsx`: `masterClasses[0].displayName` with no guard error-boundary'd the whole class page whenever a class had no upcoming sessions (live on master today). Folded in here at maintainer request.

### Fast-follows folded in (were listed under "Out of scope")

Two items originally deferred are now included in this PR (planned in the added `docs/superpowers/plans/2026-07-13-session-picker-followups.md`):

- **`components/session-picker.tsx`** — collapsed onto the shared `session-selection.ts` helpers: removed the now-caller-less `multi`/`maxSelections` mode (props, `Checkbox`, multi-only title/summary/button label) and replaced its duplicated availability + date/time logic with the shared helpers (also adopting the SAST-pinned formatters, fixing a latent un-timezoned display). **Single-select behaviour for the sole caller `related-class-card.tsx` is preserved** — the `toggleSession` change (`setSelected([])` vs the old `filter`) is equivalent for a ≤1-item selection.
- **`app/classes/[slug]/page.tsx`** — hides the entire "Choose Your Date" section (heading + tab bar) when a class has no upcoming sessions, instead of rendering an empty tab bar. The trailing "Related Classes" divider stays outside the guard.

## Testing

- `npm test` → **24/24 green** (session-selection 18, format-duration 6). `npx tsc --noEmit` clean; lint clean.
- **Verified end-to-end in a real browser (2026-07-10)** against a production Mongo dump restored into a local stack (local fusion + Pub/Sub emulator), logged in as a real user:
  - [x] Inline list renders — no "Next Session" callout, "Reserve Your Spot", "Book multiple sessions" link, or dialog.
  - [x] First selectable session pre-selected; summary "1 session selected"; total = one seat.
  - [x] Multi-select works; **6th selection refused (cap 5)**; total + "Add N Sessions to Cart" label update.
  - [x] Full sessions show "Full" + are disabled; "N spots left" otherwise.
  - [x] **Logged-in Add-to-Cart books the selected sessions → cart populated → redirect to `/cart`**; 0 console errors.
  - [x] Empty state ("No upcoming sessions available") on a class with no upcoming sessions.
  - [x] Bounded-height scroll with many (11) sessions.
  - [x] Session times render in **SAST** (validates the timezone fix).
- Fast-follows verified separately: `tsc --noEmit` + `eslint` clean on the changed files, `npm test` still 24/24; the `session-picker` refactor is behaviour-preserving for the single-mode caller.

## Out of scope (noted, not addressed here)

- **✅ Backend dependency RESOLVED — `BookSessions` panic (1pulse-digital/pepper-mint#159).** Was: `booking.manager.go:152` clobbered `cart` with nil on a failed per-item `AddToCart`, so the *next* item's `cart.AuditEntry.ETag` panicked → HTTP 500; since the inline selector books up to 5 sessions per `bookSessions` call, a non-last-item failure 500'd the whole request and bypassed the frontend's graceful partial-success path. **Fixed in pepper-mint#161 (merged):** `AddToCart` now writes to a temp cart and only commits on success, and the real error reason (e.g. "product out of stock") is propagated into `BookingError.Reason`. So multi-item booking no longer 500s on a mid-list failure, the partial-success toast (`errors > 0 && booked > 0`) now works, and failure reasons surface to the user. (Takes effect once the pepper-mint fix is deployed to prod.)
- **`components/workshop.tsx` renders session time in the host timezone** (unpinned date-fns `format`) → 2h-off hydration mismatch on the home/class workshop cards; discovered during timezone review. Underlying data is fine (dates are RFC3339 with offset) — display only. Tracked in **#119**.
- **Session `date` not validated on create in `fusion`** — only the update path enforces RFC3339; hardening, no bad rows in prod. Tracked in **1pulse-digital/pepper-mint#158**.

*(The two items previously listed here — collapsing `SessionPicker`'s `multi` branch, and the empty "Choose Your Date" tab bar — are now addressed in this PR; see "Fast-follows folded in" above.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
