### PR TITLE
fix: render workshop card session time/date in SAST (#119)

### DIFF
--- a/components/base/upcomingWorkshops.tsx
+++ b/components/base/upcomingWorkshops.tsx
@@ -4,7 +4,8 @@ import { Card, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { MasterClass } from "@/lib/fusion/masterClass/masterClass.pb"
 import { Session } from "@/lib/fusion/masterClass/session.pb"
-import { format, formatDate } from "date-fns"
+import { sessionMonthKey } from "@/lib/util/session-selection"
+import { formatDate } from "date-fns"
 import React from "react"
 import { WorkshopItem } from "../workshop"
 
@@ -23,8 +24,9 @@ export const UpcomingWorkshops: React.FC<UpcomingWorkshopsProps> = ({
   const sessionMap = new Map<string, Session[]>()
 
   sessions.forEach((session) => {
-    // Get the month of the session date
-    const yyyyMM = format(new Date(session.date), "yyyy-MM")
+    // Get the month of the session date, bucketed in SAST so a session near a
+    // UTC midnight boundary lands in the same month on the server and client.
+    const yyyyMM = sessionMonthKey(session.date)
 
     // Add the session to the corresponding month in the session map
     if (sessionMap.has(yyyyMM)) {

--- a/components/workshop.tsx
+++ b/components/workshop.tsx
@@ -7,7 +7,10 @@ import { Session } from "@/lib/fusion/masterClass/session.pb"
 import { parseError } from "@/lib/util/error"
 import { formatDuration } from "@/lib/util/format-duration"
 import { moneyFormatter } from "@/lib/util/money-formatter"
-import { format } from "date-fns"
+import {
+  formatSessionDate,
+  formatSessionTime,
+} from "@/lib/util/session-selection"
 import { CalendarClock, Clock2, User, Scale3D } from "lucide-react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
@@ -86,15 +89,14 @@ export const WorkshopItem: React.FC<WorkshopProps> = ({
   // TODO: remap behind the scenes with nexts js server side route
   const url = masterClass.name.replace("masterClasses/", "classes/")
 
-  const date = new Date(session.date)
-  const stamp = format(date, "h:mm a")
+  const stamp = formatSessionTime(session.date)
   const soldOut = session.confirmedAttendees >= masterClass.maxAttendees
   return (
     <div className="flex w-full flex-col gap-x-4 sm:flex-row ">
       <div className="grow">
         <div className="w-full">
           <span className="inline-flex items-center text-start text-primary">
-            {format(new Date(session.date), "eeee, dd MMM")}
+            {formatSessionDate(session.date)}
           </span>
           {!single && (
             <Link href={url}>

--- a/lib/util/session-selection.test.ts
+++ b/lib/util/session-selection.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest"
+import {
+  formatSessionDate,
+  formatSessionTime,
+  sessionMonthKey,
+} from "./session-selection"
+
+describe("formatSessionTime", () => {
+  it("pins to Africa/Johannesburg (UTC+2), not the host zone", () => {
+    // 07:00 UTC is 09:00 in SAST (UTC+2).
+    const result = formatSessionTime("2026-07-12T07:00:00Z")
+    expect(result).toContain("09")
+    expect(result).not.toContain("07")
+  })
+
+  it("honours an explicit +02:00 offset in the stored value", () => {
+    // 09:00 at +02:00 is already 09:00 SAST.
+    expect(formatSessionTime("2026-07-12T09:00:00+02:00")).toContain("09")
+  })
+
+  it("rolls the time across midnight in SAST near a date boundary", () => {
+    // 23:30 UTC is 01:30 the following day in SAST.
+    expect(formatSessionTime("2026-07-12T23:30:00Z")).toContain("01")
+  })
+
+  it("returns an empty string for an unparseable date", () => {
+    expect(formatSessionTime("")).toBe("")
+    expect(formatSessionTime("not-a-date")).toBe("")
+  })
+})
+
+describe("formatSessionDate", () => {
+  it("rolls the date forward when SAST has already crossed midnight", () => {
+    // 23:30 UTC on the 12th is 01:30 on the 13th in SAST.
+    expect(formatSessionDate("2026-07-12T23:30:00Z")).toContain("13")
+  })
+
+  it("keeps a mid-day UTC session on the same calendar day in SAST", () => {
+    expect(formatSessionDate("2026-07-12T09:00:00Z")).toContain("12")
+  })
+
+  it("returns an empty string for an unparseable date", () => {
+    expect(formatSessionDate("")).toBe("")
+    expect(formatSessionDate("not-a-date")).toBe("")
+  })
+})
+
+describe("sessionMonthKey", () => {
+  it("buckets by SAST month, not the host zone", () => {
+    // 2026-07-31T23:30:00Z is 2026-08-01 01:30 in SAST -> August bucket.
+    expect(sessionMonthKey("2026-07-31T23:30:00Z")).toBe("2026-08")
+  })
+
+  it("keeps a mid-month session in its own month", () => {
+    expect(sessionMonthKey("2026-07-12T09:00:00Z")).toBe("2026-07")
+  })
+
+  it("returns an empty string for an unparseable date", () => {
+    expect(sessionMonthKey("")).toBe("")
+  })
+})

--- a/lib/util/session-selection.ts
+++ b/lib/util/session-selection.ts
@@ -1,0 +1,52 @@
+// Session date/time formatting is pinned to Africa/Johannesburg (SAST, UTC+2)
+// rather than left to the runtime's local timezone. This deployment is
+// South-Africa-only, and these components are server-rendered first (UTC on
+// Cloud Run) then hydrated client-side (SAST in the browser) — without an
+// explicit timeZone the two renders disagree and React throws a hydration
+// mismatch, or worse, briefly shows a time that is 2 hours off on a booking
+// decision. South Africa observes no DST, so the offset is unambiguous
+// year-round.
+
+const SAST = "Africa/Johannesburg"
+
+function toValidDate(dateStr: string): Date | null {
+  const date = new Date(dateStr)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function formatSessionDate(dateStr: string): string {
+  const date = toValidDate(dateStr)
+  if (!date) return ""
+  return date.toLocaleDateString("en-ZA", {
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    timeZone: SAST,
+  })
+}
+
+export function formatSessionTime(dateStr: string): string {
+  const date = toValidDate(dateStr)
+  if (!date) return ""
+  return date.toLocaleTimeString("en-ZA", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: SAST,
+  })
+}
+
+// Stable "yyyy-MM" key for grouping sessions into month tabs, bucketed in SAST
+// so a session near a UTC midnight boundary lands in the month a Cape Town
+// visitor would expect — and buckets identically on the server and client.
+export function sessionMonthKey(dateStr: string): string {
+  const date = toValidDate(dateStr)
+  if (!date) return ""
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    year: "numeric",
+    month: "2-digit",
+    timeZone: SAST,
+  }).formatToParts(date)
+  const year = parts.find((p) => p.type === "year")?.value
+  const month = parts.find((p) => p.type === "month")?.value
+  return `${year}-${month}`
+}


### PR DESCRIPTION
Closes #119.

## Problem
`components/workshop.tsx` formatted the session date/time with unpinned date-fns `format()`, rendering in the **host** timezone. The component is server-rendered on Cloud Run (UTC) then hydrated in the browser (SAST, UTC+2) → React hydration mismatch and a start time **2h off** on first paint, visibly disagreeing with the already-fixed inline picker beside it on the home page, `/classes`, and `/classes/[slug]`. `components/base/upcomingWorkshops.tsx` had the same class of bug in its `yyyy-MM` month-tab key (a session near a UTC boundary could bucket into the wrong month, differing server vs client).

## Fix
- Route `workshop.tsx` time/date and the `upcomingWorkshops.tsx` month key through SAST-pinned formatters (`en-ZA`, `Africa/Johannesburg`), matching the inline picker's formatting.
- Guard empty/unparseable `session.date` (returns `""` — no "Invalid Date", no throw).
- SA observes no DST, so zone-pinning is unambiguous year-round.

> **Note:** PR #118's `lib/util/session-selection.ts` is not on `master` yet (it lives on unmerged sibling branches), so this PR adds the file using PR #118's exact `en-ZA`/`Africa/Johannesburg` formatting and **no new dependency**. Expect a trivial add/add merge conflict to union-resolve if #118 lands separately.

## Verification
- New `lib/util/session-selection.test.ts` — 10 tests (red→green), verified identical output under `TZ=UTC`, `UTC+14`, `UTC-8` (proves zone-pinning).
- `tsc --noEmit`, vitest (project tests), lint, and `build` all pass.

## Acceptance criteria
- [x] Workshop card time/date render in SAST and match the inline picker
- [x] No hydration-mismatch warning for the workshop listing
- [x] Month-tab bucketing keyed in SAST

🤖 Generated with [Claude Code](https://claude.com/claude-code)