### PR TITLE
feat: record sessions with @erick303/web-replay-sdk

### DIFF
--- a/.env
+++ b/.env
@@ -6,3 +6,8 @@ NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=329460121956
 NEXT_PUBLIC_FIREBASE_APP_ID=1:329460121956:web:8a420223fb75c6c4873a71
 NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=TODO
 NEXT_PUBLIC_API_URL=https://fusion-cva6vopela-bq.a.run.app
+
+# web-replay session recording. Write key is public by design (ships in the
+# browser bundle), so it lives here like the other NEXT_PUBLIC_* values.
+NEXT_PUBLIC_REPLAY_INGEST_URL=https://web-replay-ingest-329460121956.africa-south1.run.app/ingest
+NEXT_PUBLIC_REPLAY_WRITE_KEY=a6191c891e314a0f2b79ac162517e3de7626c0d6d2eaa0b0

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -59,6 +59,7 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      packages: 'read'
 
     runs-on: ubuntu-latest
     steps:
@@ -83,8 +84,15 @@ jobs:
           registry: '${{ env.GAR_LOCATION }}-docker.pkg.dev'
 
       - name: Build and Push Container
+        env:
+          # Reads the @erick303/web-replay-sdk package from GitHub Packages during
+          # `npm ci`. GITHUB_TOKEN works because the package is public; if a read
+          # ever fails here, replace with a PAT secret that has read:packages.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
-          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}" ./
+          docker build \
+            --secret id=node_auth_token,env=NODE_AUTH_TOKEN \
+            -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}" ./
           docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.SERVICE }}/${{ env.SERVICE }}:${{ github.sha }}"
 
       - name: Prepare tag

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@erick303:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:18-alpine AS base
 
 # Install dependencies only when needed
@@ -6,9 +7,14 @@ FROM base AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
-RUN \
+# Install dependencies based on the preferred package manager.
+# .npmrc maps the @erick303 scope to GitHub Packages; the node_auth_token
+# secret authenticates the install (GitHub's npm registry requires a token even
+# for public packages). Build with:
+#   docker build --secret id=node_auth_token,env=NODE_AUTH_TOKEN ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+RUN --mount=type=secret,id=node_auth_token \
+  export NODE_AUTH_TOKEN="$(cat /run/secrets/node_auth_token 2>/dev/null || true)"; \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \
   elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,6 +7,7 @@ import { Inter } from "next/font/google"
 import { Toaster } from "sonner"
 import "./globals.css"
 import { CartProvider } from "@/contexts/cart"
+import { ReplayInit } from "@/components/replay-init"
 import { GoogleAnalytics } from "@next/third-parties/google"
 import Script from "next/script"
 
@@ -35,6 +36,7 @@ export default function RootLayout({
         )}
       >
         <UserProvider>
+          <ReplayInit />
           <CartProvider>
             <div className="flex h-full min-h-screen w-full flex-col">
               <div className="flex h-full min-h-screen w-full flex-col">

--- a/components/replay-init.tsx
+++ b/components/replay-init.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import replay from "@erick303/web-replay-sdk"
+import { useUser } from "@/contexts/user"
+
+/**
+ * Starts web-replay session recording on the client and keeps the recorded
+ * session's identity in sync with the firebase auth state.
+ *
+ * Recording only starts when both NEXT_PUBLIC_REPLAY_INGEST_URL and
+ * NEXT_PUBLIC_REPLAY_WRITE_KEY are set — otherwise this is a no-op, so the app
+ * runs unchanged in environments where replay isn't configured.
+ *
+ * Must be rendered inside <UserProvider> so useUser() resolves.
+ */
+export function ReplayInit() {
+  const user = useUser()
+  const started = useRef(false)
+  const identified = useRef<string | null>(null)
+
+  // init once, as early as possible on the client (rrweb needs `window`, so
+  // this runs in an effect rather than during render/SSR).
+  useEffect(() => {
+    const ingestUrl = process.env.NEXT_PUBLIC_REPLAY_INGEST_URL
+    const writeKey = process.env.NEXT_PUBLIC_REPLAY_WRITE_KEY
+    if (!ingestUrl || !writeKey) return
+    if (started.current) return
+    started.current = true
+    replay.init({
+      ingestUrl,
+      writeKey,
+      appVersion: process.env.NEXT_PUBLIC_APP_VERSION,
+    })
+  }, [])
+
+  // keep the replay identity in lockstep with firebase auth.
+  useEffect(() => {
+    if (!started.current) return
+    const uid = user?.uid ?? null
+    if (uid) {
+      if (identified.current !== uid) {
+        identified.current = uid
+        replay.identify(uid, { email: user?.email ?? undefined })
+      }
+    } else if (identified.current !== null) {
+      identified.current = null
+      replay.reset()
+    }
+  }, [user])
+
+  return null
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cool-mint",
       "version": "0.1.0",
       "dependencies": {
+        "@erick303/web-replay-sdk": "^0.1.0",
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "v1",
         "@hookform/resolvers": "^3.4.2",
@@ -614,6 +615,17 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
+    },
+    "node_modules/@erick303/web-replay-sdk": {
+      "version": "0.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@erick303/web-replay-sdk/0.1.0/adea481732d6b8c7e115457abf413f0548c8877d",
+      "integrity": "sha512-K1BxrPjHZChY9SG6KyloOLOXiwalSvSHDdKq1xBbOBmenkXDqp02kKQFavjuWTGHCjYlrUIkcO6z428Bot6W7Q==",
+      "dependencies": {
+        "@rrweb/rrweb-plugin-console-record": "^2.0.1",
+        "@rrweb/types": "^2.0.0-alpha.18",
+        "@rrweb/utils": "^2.0.1",
+        "rrweb": "^2.0.0-alpha.18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -4428,6 +4440,28 @@
         "win32"
       ]
     },
+    "node_modules/@rrweb/rrweb-plugin-console-record": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.1.1.tgz",
+      "integrity": "sha512-wf5gK5/dHwguvJ/dRyENXqWrctVBMHMoegvLgJBmp+3ZvZ8HtDTgU+9zl4Qu8w8NCXQgXTxae1ksWch0UHFiUQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@rrweb/utils": "^2.1.1",
+        "rrweb": "^2.1.1"
+      }
+    },
+    "node_modules/@rrweb/types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-g0I3nCNL1S7slDXwhunxOuOoswkY8WVZJQrPFiwixOc6xoD514d1JLTuyAzCKIox8g/PaLKtV5g31Uk42inQSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@rrweb/utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.1.1.tgz",
+      "integrity": "sha512-x2SgJAD3YJ9eVcLZ5l6OqWMtczdA3VfS5XqPeqpZdQgV9oh6Id5GK2cDN4bimnkqryOcIJdz8cTvV0yNvqQ+nA==",
+      "license": "MIT"
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.3.tgz",
@@ -4724,6 +4758,12 @@
       "dependencies": {
         "classnames": "*"
       }
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -5267,6 +5307,12 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -5794,6 +5840,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -10711,6 +10766,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-2.1.6.tgz",
@@ -13453,12 +13514,46 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrdom": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.1.1.tgz",
+      "integrity": "sha512-VBkTF3bGNqcZjqnbo/gKi9GVQPIxiG0dofw7CQdAZQFQ2juJdt2YKIf3oS9QudL8HTpGh9bz5TUN+3amBn1Geg==",
+      "license": "MIT",
+      "dependencies": {
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
+    "node_modules/rrweb": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.1.1.tgz",
+      "integrity": "sha512-ToxhJg3SsrAhw+/DPhI/2iiwZQIrGK5BGkZ0kHn4qUExcvQYRaolkciD1FWX2+r6vf1IxFyhsoRY18h3D+XoCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rrweb/types": "^2.1.1",
+        "@rrweb/utils": "^2.1.1",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0",
+        "rrdom": "^2.1.1",
+        "rrweb-snapshot": "^2.1.1"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.1.1.tgz",
+      "integrity": "sha512-al4Kx7Am7YlIn/5Yb2EMr7cdmjGiK+cLhdilJEXqkFXgpnys8t/yMJumXy2Ormgirpg3MBnFha0GTgny+iIL2w==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@erick303/web-replay-sdk": "^0.1.0",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "v1",
     "@hookform/resolvers": "^3.4.2",


### PR DESCRIPTION
## What

Instrument the app with web-replay session recording.

- Install `@erick303/web-replay-sdk`; `.npmrc` resolves the `@erick303` scope from GitHub Packages.
- `components/replay-init.tsx` (`"use client"`): calls `replay.init()` in an effect (SSR-safe, since rrweb needs `window`) and keeps the replay identity in sync with firebase auth via `identify()` / `reset()`; mounted in `app/layout.tsx` inside `UserProvider`.
- `.env`: `NEXT_PUBLIC_REPLAY_INGEST_URL` + `NEXT_PUBLIC_REPLAY_WRITE_KEY`. The write key is public by design (it ships in the browser bundle), so it lives alongside the other `NEXT_PUBLIC_*` values. Recording is a no-op until both are set.
- Dockerfile + Cloud Run workflow: install the scoped package via a BuildKit token secret (GitHub's npm registry needs an authenticated token even for public packages) and grant the workflow `packages: read`.

## Verification

- `tsc --noEmit` passes (0 errors); the SDK import resolves via `moduleResolution: bundler`.
- Docker `deps` stage builds with the token secret — `npm ci` pulls the scoped package with no 401.
- The ingest endpoint is live; a manual authenticated POST returns 204 and writes to the bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
