### PR TITLE
fix(cart): stop price/controls overlapping item text

### DIFF
--- a/app/cart/components/cart-item.tsx
+++ b/app/cart/components/cart-item.tsx
@@ -44,7 +44,7 @@ export const ShoppingCartItem: React.FC<ShoppingCartItemProps> = ({
         width={90}
         className="rounded-xl"
       />
-      <div className="grow">
+      <div className="min-w-0 grow">
         <p className="text-xl">
           {item.displayName || item.product || "Product Name Not Available"}
         </p>
@@ -54,7 +54,7 @@ export const ShoppingCartItem: React.FC<ShoppingCartItemProps> = ({
           </p>
         )}
       </div>
-      <div className="flex w-[200px] flex-nowrap items-center justify-end gap-2 font-bold text-primary">
+      <div className="flex shrink-0 flex-nowrap items-center justify-end gap-2 font-bold text-primary">
         <MoneyField value={item.price} />
         <Button onClick={handleDecreaseQuantity} disabled={item.quantity <= 1n}>
           -


### PR DESCRIPTION
## Summary

On the cart page the price and quantity controls overlapped the item name/date (see reported issue on `/cart`).

The controls column used a fixed `w-[200px]`, but its content — price + `-`/`+` buttons + `x N` input + delete button — is wider than 200px. Combined with `flex-nowrap` and `justify-end`, the overflow spilled *leftward* out of the box and landed on top of the adjacent name/date column.

## Fix

- `app/cart/components/cart-item.tsx`
  - Controls column: `w-[200px]` → `shrink-0` so it takes the width its content needs and never shrinks.
  - Name column: added `min-w-0` to the `grow` div so it can actually yield space to the controls column (flex items default to `min-width: auto`).

## Testing

Ran the storefront locally against the production API and viewed a real cart (`CNC Cabinetry` item) via Playwright — price and controls now sit cleanly to the right of the name/date with no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)